### PR TITLE
fix(bsp-can): restore bxcan filter bank from fifo-local match index

### DIFF
--- a/platform/bsp/boards/rm-a-board/source/peripherals/can/bsp_can_impl.c
+++ b/platform/bsp/boards/rm-a-board/source/peripherals/can/bsp_can_impl.c
@@ -433,12 +433,21 @@ static OmRet bsp_can_recv_msg(HalCanHandler* can, CanHwMsg* msg, int32_t rxfifo_
     msg->dsc.msgType = (rx_header.RTR == CAN_RTR_DATA) ? CAN_MSG_TYPE_DATA : CAN_MSG_TYPE_REMOTE;
     msg->dsc.dataLen = rx_header.DLC; 
     // 标准 CAN 数据长度范围 0~8，按 HAL 返回 DLC 直接透传
-    // FilterMatchIndex 是本 CAN 实例内索引，需要换算为全局硬件 bank
-    int16_t hwFilterBank = (int16_t)rx_header.FilterMatchIndex;
+    /* bxCAN 返回的 FilterMatchIndex 是“当前 FIFO 内命中的过滤器序号”，
+     * 不是全局 bank 编号。当前 BSP 固定按 bank 奇偶分配 FIFO：
+     * - 偶数 bank -> FIFO0
+     * - 奇数 bank -> FIFO1
+     * 且全部使用 32bit filter，因此可以按 FIFO 内序号还原真实 bank。
+     */
+    int16_t hwFilterBank = (int16_t)(rx_header.FilterMatchIndex * 2u + (uint32_t)rxfifo_bank);
 #ifdef USE_CAN2
     if (hcan->Instance == CAN2)
         hwFilterBank = (int16_t)(hwFilterBank + (int16_t)BSP_CAN_FILTER_SPLIT_BANK);
 #endif
+    if (msg->dsc.dataLen > 8u)
+    {
+        return OM_ERROR_PARAM;
+    }
     msg->hwFilterBank = hwFilterBank;
     msg->hwTxMailbox = -1;
     msg->dsc.timeStamp = rx_header.Timestamp;
@@ -469,6 +478,11 @@ static OmRet bsp_can_send_msg(HalCanHandler* can, CanHwMsg* msg)
     tx_header.RTR = (msg->dsc.msgType == CAN_MSG_TYPE_REMOTE) ? CAN_RTR_REMOTE : CAN_RTR_DATA;
     tx_header.DLC = msg->dsc.dataLen;
     tx_header.TransmitGlobalTime = DISABLE; // 不使能全局时间戳回传
+    if (msg->dsc.dataLen > 8u || (msg->dsc.dataLen > 0u && msg->data == NULL))
+    {
+        msg->hwTxMailbox = -1;
+        return OM_ERROR_PARAM;
+    }
     // 拷贝发送数据
     uint8_t data[8];
     if (msg->data != NULL && msg->dsc.dataLen > 0)

--- a/platform/bsp/boards/rm-c-board/source/peripherals/can/bsp_can_impl.c
+++ b/platform/bsp/boards/rm-c-board/source/peripherals/can/bsp_can_impl.c
@@ -433,12 +433,21 @@ static OmRet bsp_can_recv_msg(HalCanHandler* can, CanHwMsg* msg, int32_t rxfifo_
     msg->dsc.msgType = (rx_header.RTR == CAN_RTR_DATA) ? CAN_MSG_TYPE_DATA : CAN_MSG_TYPE_REMOTE;
     msg->dsc.dataLen = rx_header.DLC; 
     // 标准 CAN 数据长度范围 0~8，按 HAL 返回 DLC 直接透传
-    // FilterMatchIndex 是本 CAN 实例内索引，需要换算为全局硬件 bank
-    int16_t hwFilterBank = (int16_t)rx_header.FilterMatchIndex;
+    /* bxCAN 返回的 FilterMatchIndex 是“当前 FIFO 内命中的过滤器序号”，
+     * 不是全局 bank 编号。当前 BSP 固定按 bank 奇偶分配 FIFO：
+     * - 偶数 bank -> FIFO0
+     * - 奇数 bank -> FIFO1
+     * 且全部使用 32bit filter，因此可以按 FIFO 内序号还原真实 bank。
+     */
+    int16_t hwFilterBank = (int16_t)(rx_header.FilterMatchIndex * 2u + (uint32_t)rxfifo_bank);
 #ifdef USE_CAN2
     if (hcan->Instance == CAN2)
         hwFilterBank = (int16_t)(hwFilterBank + (int16_t)BSP_CAN_FILTER_SPLIT_BANK);
 #endif
+    if (msg->dsc.dataLen > 8u)
+    {
+        return OM_ERROR_PARAM;
+    }
     msg->hwFilterBank = hwFilterBank;
     msg->hwTxMailbox = -1;
     msg->dsc.timeStamp = rx_header.Timestamp;
@@ -469,6 +478,11 @@ static OmRet bsp_can_send_msg(HalCanHandler* can, CanHwMsg* msg)
     tx_header.RTR = (msg->dsc.msgType == CAN_MSG_TYPE_REMOTE) ? CAN_RTR_REMOTE : CAN_RTR_DATA;
     tx_header.DLC = msg->dsc.dataLen;
     tx_header.TransmitGlobalTime = DISABLE; // 不使能全局时间戳回传
+    if (msg->dsc.dataLen > 8u || (msg->dsc.dataLen > 0u && msg->data == NULL))
+    {
+        msg->hwTxMailbox = -1;
+        return OM_ERROR_PARAM;
+    }
     // 拷贝发送数据
     uint8_t data[8];
     if (msg->data != NULL && msg->dsc.dataLen > 0)


### PR DESCRIPTION
## 🎯 修改目的
- 修复 bxCAN 接收路径把 `FilterMatchIndex` 误当成全局 bank 编号的问题，恢复为按 `FIFO0 -> even bank`、`FIFO1 -> odd bank` 推导真实硬件 bank。
- 防止多 filter、多 vendor 共存时接收分发表命中错误 bank，导致回调分发偏移。
- 同时补齐 `rm-a` / `rm-c` 两块板子的 CAN 收发 `dataLen > 8` 与空数据指针防护。

## 🧩 涉及的框架维度 (可多选)
请明确本次 PR 主要修改的模块范围，以便审查者调整关注重点：

- [x] **硬件与驱动** (BSP, Driver等)
- [ ] **系统与机制** (OSAL, Sync, Async、Middleware，Service等)
- [ ] **数据结构与算法** (通用数据结构, 通用算法库等)
- [ ] **文档或示例** (Sample 演示代码, Docs)
- [ ] **构建与基建** (XMake 工程配置, 编译脚本等)
- [ ] **应用与服务** (app模板, 应用层服务等)

## 🔄 变更类型
- [x] 🐛 Bug 修复 (修复了某处逻辑缺陷或硬件时序问题)
- [ ] ✨ 新特性 (新增了全新的外设模块、数据结构或适配了新板子)
- [ ] ♻️ 代码重构 (优化代码结构，不改变对外接口行为)
- [ ] 📝 文档更新 (添加了 API 注释或说明文档)
- [ ] 🔧 配置变更 (如修改了 XMake 工程配置、编译脚本等)
- [ ] 🔨 工具变更 (如升级了开发工具链、添加了新的依赖库等)
- [ ] 🔄 其他变更 (如修改了文件结构、编码风格调整等)

## 🛠️ 测试验证说明
**1. 对于纯软件逻辑（如数据结构、OSAL、算法）**：
- [ ] 已在本地通过 XMake 编译，并补充/运行了对应的单元测试用例。
- [ ] 补充说明（如高并发压力测试结果、死锁/竞态条件边界测试）：

**2. 对于硬件关联代码（如 BSP、Driver、控制对象）**：
- [x] 说明测试使用的硬件平台/开发板型号：代码覆盖 `rm-a-board` / `rm-c-board`，当前集成构建验证使用 `rm-a-board`
- [ ] 补充证明（请在此附上关键的日志输出、关键信号波形图截图等）：未补双板实机波形；已完成 `git diff --check`，并在集成工作区通过 `xmake build new_robot`

## ⚠️ 影响范围分析
- 是否修改了现有的对外 API 接口？👉 [ 否 ]  *(如果是，请列出受影响的模块)*
- 是否修改了现有的对外数据结构？👉 [ 否 ]  *(如果是，请列出受影响的模块)*

## 🔗 Issue 关联与关闭策略
- 目标为 `integration`（`feature/*`、`fix/*`）：使用 `Refs #<issue编号>`（仅关联，不关闭）。
- 目标为 `main`（`hotfix/*` 或 `integration -> main` 发布 PR）：使用 `Fixes #<issue编号>`（自动关闭）。
- 关闭关键字仅允许使用 `Fixes`，不使用 `Resolves`。
- 本 PR 填写：
  - `Refs #10`

## ✅ 提交者自查清单
在向 `integration` 分支发起合并前，请确认：
- [x] 代码风格符合团队统一规范，变量/函数命名语义清晰。
- [x] 核心复杂逻辑（尤其是无锁操作、硬件时序打断等）已添加了充分的中文注释。
- [x] 本地分支已经基于最新的 `integration` 分支同步过代码，确保当前无冲突。
- [x] 本次提交序列已按单一职责拆分，不存在“功能+修复+格式化”混合提交。
- [x] 若涉及跨层接口/签名变更，调用方已在同一提交内完成闭环，历史提交可编译。
- [x] 未夹带无关注释、空行或排版改动；纯格式化已独立为 `style(...)` 提交。
- [x] 提交信息符合 `类型(作用域): 简短描述`，类型仅使用 `feat/fix/docs/style/refactor/chore`。

> 说明：本 PR 有意不夹带 `rm-a` 的 45MHz 时序表调整；那部分已拆为独立板级基线 PR。
