### PR TITLE
fix(board): adapt delayMs callback to millisecond contract

### DIFF
--- a/platform/bsp/boards/rm-a-board/source/core/bsp_cpu.c
+++ b/platform/bsp/boards/rm-a-board/source/core/bsp_cpu.c
@@ -15,6 +15,11 @@ static void Error_Handler(void)
     }
 }
 
+static void Board_DelayMs(float ms)
+{
+    DWT_Delay(ms / 1000.0f);
+}
+
 /**
  * @brief System Clock Configuration
  * @retval None
@@ -66,7 +71,7 @@ static OmBoardInterface g_om_board_interface = {
     .getCpuTimeMs = DWT_GetTimeline_ms,
     .getCpuTimeUs = DWT_GetTimeline_us,
     .getDeltaCpuTimeS = DWT_GetDeltaT,
-    .delayMs = DWT_Delay,
+    .delayMs = Board_DelayMs,
 };
 
 void om_board_init(void)

--- a/platform/bsp/boards/rm-c-board/source/core/bsp_cpu.c
+++ b/platform/bsp/boards/rm-c-board/source/core/bsp_cpu.c
@@ -15,6 +15,11 @@ static void Error_Handler(void)
     }
 }
 
+static void Board_DelayMs(float ms)
+{
+    DWT_Delay(ms / 1000.0f);
+}
+
 /**
  * @brief System Clock Configuration
  * @retval None
@@ -66,7 +71,7 @@ static OmBoardInterface g_om_board_interface = {
     .getCpuTimeMs = DWT_GetTimeline_ms,
     .getCpuTimeUs = DWT_GetTimeline_us,
     .getDeltaCpuTimeS = DWT_GetDeltaT,
-    .delayMs = DWT_Delay,
+    .delayMs = Board_DelayMs,
 };
 
 void om_board_init(void)


### PR DESCRIPTION
## 🎯 修改目的
- 修正 `OmBoardInterface.delayMs(float ms)` 的单位语义，让板级实现与接口契约保持一致。
- 避免直接把 `DWT_Delay` 作为 `delayMs` 回调使用时出现“接口要求 ms，底层实现按秒量级解释”的语义错配。
- 在 `rm-a-board` 与 `rm-c-board` 上统一引入 `Board_DelayMs(ms / 1000.0f)` 包装，避免同类问题重复出现。

## 🧩 涉及的框架维度 (可多选)
请明确本次 PR 主要修改的模块范围，以便审查者调整关注重点：

- [x] **硬件与驱动** (BSP, Driver等)
- [ ] **系统与机制** (OSAL, Sync, Async、Middleware，Service等)
- [ ] **数据结构与算法** (通用数据结构, 通用算法库等)
- [ ] **文档或示例** (Sample 演示代码, Docs)
- [ ] **构建与基建** (XMake 工程配置, 编译脚本等)
- [ ] **应用与服务** (app模板, 应用层服务等)

## 🔄 变更类型
- [x] 🐛 Bug 修复 (修复了某处逻辑缺陷或硬件时序问题)
- [ ] ✨ 新特性 (新增了全新的外设模块、数据结构或适配了新板子)
- [ ] ♻️ 代码重构 (优化代码结构，不改变对外接口行为)
- [ ] 📝 文档更新 (添加了 API 注释或说明文档)
- [ ] 🔧 配置变更 (如修改了 XMake 工程配置、编译脚本等)
- [ ] 🔨 工具变更 (如升级了开发工具链、添加了新的依赖库等)
- [ ] 🔄 其他变更 (如修改了文件结构、编码风格调整等)

## 🛠️ 测试验证说明
**1. 对于纯软件逻辑（如数据结构、OSAL、算法）**：
- [ ] 已在本地通过 XMake 编译，并补充/运行了对应的单元测试用例。
- [ ] 补充说明（如高并发压力测试结果、死锁/竞态条件边界测试）：

**2. 对于硬件关联代码（如 BSP、Driver、控制对象）**：
- [x] 说明测试使用的硬件平台/开发板型号：代码覆盖 `rm-a-board` / `rm-c-board`，当前集成构建验证使用 `rm-a-board`
- [ ] 补充证明（请在此附上关键的日志输出、关键信号波形图截图等）：未补板上延时波形；已完成 `git diff --check`，并在集成工作区通过 `xmake build new_robot`

## ⚠️ 影响范围分析
- 是否修改了现有的对外 API 接口？👉 [ 否 ]  *(如果是，请列出受影响的模块)*
- 是否修改了现有的对外数据结构？👉 [ 否 ]  *(如果是，请列出受影响的模块)*

## 🔗 Issue 关联与关闭策略
- 目标为 `integration`（`feature/*`、`fix/*`）：使用 `Refs #<issue编号>`（仅关联，不关闭）。
- 目标为 `main`（`hotfix/*` 或 `integration -> main` 发布 PR）：使用 `Fixes #<issue编号>`（自动关闭）。
- 关闭关键字仅允许使用 `Fixes`，不使用 `Resolves`。
- 本 PR 填写：
  - `Refs #10`

## ✅ 提交者自查清单
在向 `integration` 分支发起合并前，请确认：
- [x] 代码风格符合团队统一规范，变量/函数命名语义清晰。
- [x] 核心复杂逻辑（尤其是无锁操作、硬件时序打断等）已添加了充分的中文注释。
- [x] 本地分支已经基于最新的 `integration` 分支同步过代码，确保当前无冲突。
- [x] 本次提交序列已按单一职责拆分，不存在“功能+修复+格式化”混合提交。
- [x] 若涉及跨层接口/签名变更，调用方已在同一提交内完成闭环，历史提交可编译。
- [x] 未夹带无关注释、空行或排版改动；纯格式化已独立为 `style(...)` 提交。
- [x] 提交信息符合 `类型(作用域): 简短描述`，类型仅使用 `feat/fix/docs/style/refactor/chore`。

> 说明：本 PR 只处理 `delayMs` 的接口契约，不夹带 `rm-a` 的 180MHz 板级基线调整。
