### PR TITLE
fix(rm-a-board): align sysclk and can timing with 180MHz baseline 

### DIFF
--- a/platform/bsp/boards/rm-a-board/source/core/bsp_cpu.c
+++ b/platform/bsp/boards/rm-a-board/source/core/bsp_cpu.c
@@ -37,10 +37,18 @@ static void SystemClock_Config(void)
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
     RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
     RCC_OscInitStruct.PLL.PLLM = 6;
-    RCC_OscInitStruct.PLL.PLLN = 168;
+    RCC_OscInitStruct.PLL.PLLN = 180;
     RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
-    RCC_OscInitStruct.PLL.PLLQ = 4;
+    RCC_OscInitStruct.PLL.PLLQ = 8;
     if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
+    {
+        Error_Handler();
+    }
+
+    /* 与旧工程对齐到 180MHz SYSCLK。
+     * STM32F427 在 Scale1 下跑 180MHz 需要打开 OverDrive。
+     */
+    if (HAL_PWREx_EnableOverDrive() != HAL_OK)
     {
         Error_Handler();
     }

--- a/platform/bsp/boards/rm-a-board/source/peripherals/can/bsp_can_impl.c
+++ b/platform/bsp/boards/rm-a-board/source/peripherals/can/bsp_can_impl.c
@@ -154,17 +154,28 @@ static OmRet bsp_can_clear_filter(CAN_HandleTypeDef* hcan, size_t bank)
     return OM_OK;
 }
 
-// 常用波特率预设参数（假设 CAN 内核时钟为 42MHz）。
+// 常用波特率预设参数（rm-a-board 当前 APB1 = 45MHz）。
 static CanTimeCfg BspCanBitTimeTable[] = {
-    {CAN_BAUD_10K, 300, {CAN_TSEG1_9TQ, CAN_TSEG2_4TQ, CAN_SYNCJW_2TQ}},
-    {CAN_BAUD_20K, 150, {CAN_TSEG1_9TQ, CAN_TSEG2_4TQ, CAN_SYNCJW_2TQ}},
-    {CAN_BAUD_50K, 60, {CAN_TSEG1_9TQ, CAN_TSEG2_4TQ, CAN_SYNCJW_2TQ}},
-    {CAN_BAUD_100K, 30, {CAN_TSEG1_9TQ, CAN_TSEG2_4TQ, CAN_SYNCJW_2TQ}},
-    {CAN_BAUD_125K, 24, {CAN_TSEG1_9TQ, CAN_TSEG2_4TQ, CAN_SYNCJW_2TQ}},
-    {CAN_BAUD_250K, 12, {CAN_TSEG1_9TQ, CAN_TSEG2_4TQ, CAN_SYNCJW_2TQ}},
-    {CAN_BAUD_500K, 6, {CAN_TSEG1_9TQ, CAN_TSEG2_4TQ, CAN_SYNCJW_2TQ}},
-    {CAN_BAUD_800K, 4, {CAN_TSEG1_8TQ, CAN_TSEG2_4TQ, CAN_SYNCJW_2TQ}},
-    {CAN_BAUD_1M, 3, {CAN_TSEG1_9TQ, CAN_TSEG2_4TQ, CAN_SYNCJW_2TQ}},
+    /* 10K ~ 500K 与 1M 统一采用 15TQ / 86.7% 采样点风格：
+     * bitrate = 45MHz / PSC / (1 + 12 + 2)
+     */
+    {CAN_BAUD_10K, 300, {CAN_TSEG1_12TQ, CAN_TSEG2_2TQ, CAN_SYNCJW_1TQ}},
+    {CAN_BAUD_20K, 150, {CAN_TSEG1_12TQ, CAN_TSEG2_2TQ, CAN_SYNCJW_1TQ}},
+    {CAN_BAUD_50K, 60, {CAN_TSEG1_12TQ, CAN_TSEG2_2TQ, CAN_SYNCJW_1TQ}},
+    {CAN_BAUD_100K, 30, {CAN_TSEG1_12TQ, CAN_TSEG2_2TQ, CAN_SYNCJW_1TQ}},
+    {CAN_BAUD_125K, 24, {CAN_TSEG1_12TQ, CAN_TSEG2_2TQ, CAN_SYNCJW_1TQ}},
+    {CAN_BAUD_250K, 12, {CAN_TSEG1_12TQ, CAN_TSEG2_2TQ, CAN_SYNCJW_1TQ}},
+    {CAN_BAUD_500K, 6, {CAN_TSEG1_12TQ, CAN_TSEG2_2TQ, CAN_SYNCJW_1TQ}},
+    /* 45MHz 下无法精确整分出 800kbps，这里选择最接近且采样点仍合理的一组：
+     * 45MHz / 4 / (1 + 11 + 2) = 803.6kbps, sample point = 85.7%
+     */
+    {CAN_BAUD_800K, 4, {CAN_TSEG1_11TQ, CAN_TSEG2_2TQ, CAN_SYNCJW_1TQ}},
+    /* ST 官方推荐的 bxCAN 1Mbps 配置之一：
+     * APB1 = 45MHz, PSC = 3, BS1 = 12TQ, BS2 = 2TQ, SJW = 1TQ
+     * 实际位率 = 45MHz / 3 / (1 + 12 + 2) = 1Mbps
+     * 采样点 = (1 + 12) / (1 + 12 + 2) = 86.7%
+     */
+    {CAN_BAUD_1M, 3, {CAN_TSEG1_12TQ, CAN_TSEG2_2TQ, CAN_SYNCJW_1TQ}},
 };
 
 static CanTimeCfg* bsp_can_time_cfg_matched(CanBaudRate baud)


### PR DESCRIPTION
## 🎯 修改目的
- 将 `rm-a-board` 的时钟树与既有板级基线对齐到 `180MHz + OverDrive`。
- 由于 `APB1` 随之变为 `45MHz`，同步修正 `rm-a-board` 的 CAN 位时序表，避免沿用 `42MHz` 假设造成波特率失配。
- 让 `rm-a-board` 的 CPU 时钟配置和 CAN 时序配置保持同一板级事实来源，避免半更新状态。

## 🧩 涉及的框架维度 (可多选)
请明确本次 PR 主要修改的模块范围，以便审查者调整关注重点：

- [x] **硬件与驱动** (BSP, Driver等)
- [ ] **系统与机制** (OSAL, Sync, Async、Middleware，Service等)
- [ ] **数据结构与算法** (通用数据结构, 通用算法库等)
- [ ] **文档或示例** (Sample 演示代码, Docs)
- [ ] **构建与基建** (XMake 工程配置, 编译脚本等)
- [ ] **应用与服务** (app模板, 应用层服务等)

## 🔄 变更类型
- [x] 🐛 Bug 修复 (修复了某处逻辑缺陷或硬件时序问题)
- [ ] ✨ 新特性 (新增了全新的外设模块、数据结构或适配了新板子)
- [ ] ♻️ 代码重构 (优化代码结构，不改变对外接口行为)
- [ ] 📝 文档更新 (添加了 API 注释或说明文档)
- [x] 🔧 配置变更 (如修改了 XMake 工程配置、编译脚本等)
- [ ] 🔨 工具变更 (如升级了开发工具链、添加了新的依赖库等)
- [ ] 🔄 其他变更 (如修改了文件结构、编码风格调整等)

## 🛠️ 测试验证说明
**1. 对于纯软件逻辑（如数据结构、OSAL、算法）**：
- [ ] 已在本地通过 XMake 编译，并补充/运行了对应的单元测试用例。
- [ ] 补充说明（如高并发压力测试结果、死锁/竞态条件边界测试）：

**2. 对于硬件关联代码（如 BSP、Driver、控制对象）**：
- [x] 说明测试使用的硬件平台/开发板型号：`rm-a-board`
- [ ] 补充证明（请在此附上关键的日志输出、关键信号波形图截图等）：未补板上时钟/波形截图；已完成 `git diff --check`，并在集成工作区通过 `xmake build new_robot`

## ⚠️ 影响范围分析
- 是否修改了现有的对外 API 接口？👉 [ 否 ]  *(如果是，请列出受影响的模块)*
- 是否修改了现有的对外数据结构？👉 [ 否 ]  *(如果是，请列出受影响的模块)*

## 🔗 Issue 关联与关闭策略
- 目标为 `integration`（`feature/*`、`fix/*`）：使用 `Refs #<issue编号>`（仅关联，不关闭）。
- 目标为 `main`（`hotfix/*` 或 `integration -> main` 发布 PR）：使用 `Fixes #<issue编号>`（自动关闭）。
- 关闭关键字仅允许使用 `Fixes`，不使用 `Resolves`。
- 本 PR 填写：
  - `Refs #10`

## ✅ 提交者自查清单
在向 `integration` 分支发起合并前，请确认：
- [x] 代码风格符合团队统一规范，变量/函数命名语义清晰。
- [x] 核心复杂逻辑（尤其是无锁操作、硬件时序打断等）已添加了充分的中文注释。
- [x] 本地分支已经基于最新的 `integration` 分支同步过代码，确保当前无冲突。
- [x] 本次提交序列已按单一职责拆分，不存在“功能+修复+格式化”混合提交。
- [x] 若涉及跨层接口/签名变更，调用方已在同一提交内完成闭环，历史提交可编译。
- [x] 未夹带无关注释、空行或排版改动；纯格式化已独立为 `style(...)` 提交。
- [x] 提交信息符合 `类型(作用域): 简短描述`，类型仅使用 `feat/fix/docs/style/refactor/chore`。

> 说明：本 PR 有意将 `rm-a` 的 180MHz 基线与 45MHz CAN 时序表绑定在同一条变更里，避免只改时钟或只改位时序导致板级事实不一致。
