### PR TITLE
feat(ipc): 创建 IPC 跨上下文数据传输层并迁移 Pipe

### DIFF
--- a/build/xmake.lua
+++ b/build/xmake.lua
@@ -1,4 +1,4 @@
-﻿--- @file oh_my_robot/build/xmake.lua
+--- @file oh_my_robot/build/xmake.lua
 --- @brief OM 构建入口
 --- @details 负责加载构建配置、规则、工具链与模块入口。
 set_xmakever("3.0.7")
@@ -13,6 +13,7 @@ includes("tasks")
 includes("../lib")
 includes("../platform/osal")
 includes("../platform/sync")
+includes("../platform/ipc")
 includes("../platform/bsp")
 
 --- @target tar_oh_my_robot
@@ -24,7 +25,8 @@ target("tar_oh_my_robot")
     add_deps("tar_awosal_probe", {public = true})
     add_deps("tar_awalgo", {public = true})
     add_deps("tar_awdrivers", {public = true})
-    add_deps("tar_awasync", {public = true})
+    add_deps("tar_async", {public = true})
+    add_deps("tar_ipc", {public = true})
     add_deps("tar_awsystems", {public = true})
     add_deps("tar_bsp", {public = true})
     add_deps("tar_osal", {public = true})

--- a/docs/adr/0009-ipc_layer_and_pipe_migration.md
+++ b/docs/adr/0009-ipc_layer_and_pipe_migration.md
@@ -1,0 +1,38 @@
+# ADR-0009 IPC 层创建与 Pipe 迁移
+
+## 背景 (Context)
+
+- `lib/sync/` 当前包含两类本质不同的模块：纯同步信号原语（`completion`）和带数据载荷的传输通道（`pipe`）。
+- `pipe` 基于 `Ringbuf + 双二值信号量` 实现，核心价值是**跨上下文数据传输**（Task ↔ Task、ISR → Task、Task → ISR），而非同步通知。
+- `completion` 回答"某事件是否已发生"，无数据载荷；`pipe` 回答"有没有数据？给我/拿走"，有数据载荷。两者语义不匹配。
+- 若继续将 `pipe` 留在 `sync/`，未来加入类型化通道（`spsc_channel`）、广播通道等机制时，`sync/` 会变成无区分度的大杂烩。
+- 按通信方（任务间、ISR→Task、Task→ISR、核间）建子目录会导致代码笛卡尔积膨胀；按通信机制建目录（pipe/channel/broadcast）并用 `_from_isr` 变体覆盖通信方，是更合理的分类方式。
+
+## 考虑过的方案 (Options)
+
+- **方案 A**：保持 `sync/`，扩展其语义定义为"并发协作层"。零重构，但 `sync/` 语义模糊，未来扩展方向混乱。
+- **方案 B**：新建 `ipc/` 层，将 Pipe 迁移至 `lib/ipc/`。`sync/` 回归纯同步信号（completion、future event、barrier），`ipc/` 承载跨上下文数据通道。
+- **方案 C**：Pipe 回退到 `osal/` 层，与 `osal_queue` 并列。但 Pipe 是组合产物（ringbuf + sem），不符合 OSAL"最小可移植原语"定位。
+
+## 最终决策 (Decision)
+
+- 采用**方案 B**：创建 `lib/ipc/` 跨上下文数据传输层，将 Pipe 从 `lib/sync/` 迁移至此。
+- 层级定位（自底向上）：
+  ```
+  sync     → 纯同步信号（completion, future event, barrier...），无数据载荷
+  ipc      → 跨上下文数据通道（pipe, future channel, broadcast...），有数据载荷
+  services/comm → 结构化消息通信（帧格式、路由、发布订阅），构建在 ipc 之上
+  ```
+- 组织方式：按通信机制建目录，通信方作为 API 变体（`_from_isr` 后缀）。
+- 依赖约束：`ipc/` 依赖 `core + osal`，不依赖 `services/drivers/systems`。
+- Pipe 头文件守卫从 `OM_SYNC_PIPE_H` 更新为 `OM_IPC_PIPE_H`。
+- 构建对象：新增 `tar_awapi_ipc`（headeronly 接口目标）和 `tar_ipc`（静态库目标）。
+
+## 影响 (Consequences)
+
+- `sync/` 目录仅保留 `completion`，语义明确回归"纯同步信号"。
+- 所有依赖 Pipe 的上层模块需更新 include 路径：`sync/pipe.h` → `ipc/pipe.h`。
+- `tar_awapi_ipc` 作为 headeronly 目标被 `tar_awapi_async` 和 `tar_awapi_driver` 传递依赖，保证 IPC 头文件在构建系统中可见。
+- 未来新增通道机制（如 `spsc_channel`、`broadcast`）直接在 `lib/ipc/` 下扩展，不污染 `sync/`。
+- 核间 IPC 抽象为 future scope，届时在 `ipc/` 下追加 `ipc_core.h` 或 `inter_core/` 子目录。
+- 相关规范更新：`layer_dependency_spec.md`、`build/xmake.lua`、`lib/xmake.lua`、`sync/README.md`。

--- a/docs/architecture/layer_dependency_spec.md
+++ b/docs/architecture/layer_dependency_spec.md
@@ -1,11 +1,11 @@
-﻿# OM 分层与依赖规范（长期稳定）
-本文用于明确 **core / OSAL / sync / services(comm) / drivers / systems** 的职责边界与依赖方向，目标是：
+# OM 分层与依赖规范（长期稳定）
+本文用于明确 **core / OSAL / sync / ipc / services(comm) / drivers / systems** 的职责边界与依赖方向，目标是：
 - 让模块可复用、可移植、可扩展
 - 避免循环依赖与层级倒置
 - 允许在关键路径做端口级性能优化，但不污染公共 API
 
 ## 规范来源约束（强制）
-- 本文档 [`oh-my-robot/docs/architecture/layer_dependency_spec.md`](layer_dependency_spec.md) 是全仓“分层与依赖方向”的唯一总规范源。
+- 本文档 [`oh-my-robot/docs/architecture/layer_dependency_spec.md`](layer_dependency_spec.md) 是全仓"分层与依赖方向"的唯一总规范源。
 - 其他文档（OSAL/SYNC、services、drivers、build）只能做专项补充，必须引用本文，不得重新定义总依赖矩阵。
 
 ## 名词与层级
@@ -19,7 +19,7 @@
 - 含义：芯片板卡初始化、外设底层配置、与具体 MCU 强耦合
 - 边界：仅处理板级硬件初始化、时钟/引脚/外设物理连接与启动文件；不承担 OSAL 端口或业务语义
 - 可依赖：[`lib/include/core`](../../lib/include/core)、[`lib/drivers`](../../lib/drivers)（通过 PAL 接口）、`third_party`
-- 禁止依赖：[`lib/osal`](../../lib/osal)、`lib/include/sync`、[`lib/services`](../../lib/services)、[`lib/systems`](../../lib/systems)（避免 OS/业务语义下沉到 BSP）
+- 禁止依赖：[`lib/osal`](../../lib/osal)、`lib/include/sync`、`lib/ipc`、[`lib/services`](../../lib/services)、[`lib/systems`](../../lib/systems)（避免 OS/业务语义下沉到 BSP）
 ### 3) [`platform/`](../../platform/)（端口与平台适配）
 - 含义：OSAL 端口与平台族适配实现
 - 边界：包含 OSAL 端口、架构/工具链/ABI 适配与 RTOS 绑定；不包含板级初始化与外设物理连接
@@ -30,37 +30,47 @@
 - 含义：基础类型/错误码/通用宏、平台无关的轻量工具与配置定义
 - 边界：不包含 OS、设备驱动、业务语义；不持有端口或板级细节
 - 可依赖：必要的 `third_party`（需封装在实现或内部头）
-- 禁止依赖：`osal/sync/drivers/services/systems/bsp/platform`
+- 禁止依赖：`osal/sync/ipc/drivers/services/systems/bsp/platform`
 
 ### 5) [`lib/osal/`](../../lib/osal/)（操作系统抽象层：最小原语集）
 - 含义：对 RTOS/系统调用做最小可移植抽象（线程/互斥/信号量/队列/时间/定时器事件对象等）
 - 规则：
-  - OSAL 只定义“端口必须实现”的最小原语
+  - OSAL 只定义"端口必须实现"的最小原语
   - OSAL 不承诺更高层语义（例如 completion、消息总线等）
 - 可依赖：[`lib/include/core`](../../lib/include/core)
 - 说明：端口实现放在 [`platform/`](../../platform/) 中，避免 OSAL 公共接口混杂
 
-### 6) `lib/include/sync` + [`lib/sync/src`](../../lib/sync/src)（同步语义层：组合原语）
-- 含义：基于 OSAL 原语组合出的同步抽象（例如 completion、barrier 等）
+### 6) `lib/include/sync` + [`lib/sync/src`](../../lib/sync/src)（同步语义层：纯同步信号）
+- 含义：基于 OSAL 原语组合出的纯同步信号抽象（例如 completion、future event、barrier 等），无数据载荷
+- 与 `ipc/` 的区别：sync 只传递"事件信号"，不传递数据；ipc 传递"数据载荷"
 - 规则：
   - 对外 API 不暴露具体 RTOS 类型
   - 默认实现仅依赖 OSAL（保证所有端口可用）
-  - 可选加速实现必须满足“同任务跨模块可复用”约束；不满足则禁止作为正式后端
+  - 可选加速实现必须满足"同任务跨模块可复用"约束；不满足则禁止作为正式后端
   - completion 当前固定为 reference 实现（基于 OSAL 原语），不提供 notify 后端
 
-### 7) [`lib/services`](../../lib/services)（通用服务）
+### 7) [`lib/ipc/`](../../lib/ipc/)（跨上下文数据传输层）
+- 含义：跨上下文（Task ↔ Task / ISR → Task / Task → ISR）的字节流/消息传输通道，有数据载荷
+- 与 `sync/` 的区别：ipc 传输带数据的通道（pipe、future channel、broadcast 等），sync 只传递事件信号
+- 与 `services/comm/` 的区别：ipc 提供无结构的字节流/类型化队列，comm 提供带帧格式和路由的结构化消息
+- 组织方式：按通信机制建目录（pipe/channel/broadcast），通信方作为 API 变体（`_from_isr` 后缀）
+- 可依赖：[`lib/osal`](../../lib/osal)、[`lib/include/core`](../../lib/include/core)
+- 禁止依赖：`services/drivers/systems`
+- 核间 IPC 抽象为 future scope
+
+### 8) [`lib/services`](../../lib/services)（通用服务）
 - 含义：可复用服务组件（log、config、comm、fs、diagnostics 等）
-- `comm`（服务层）含义：跨线程跨模块的通信语义（消息请求响应/发布订阅等），而非基础同步原语
-- 可依赖：[`lib/osal`](../../lib/osal)、[`lib/include/core`](../../lib/include/core)、`lib/include/sync`
+- `comm`（服务层）含义：跨线程跨模块的通信语义（消息请求响应/发布订阅等），构建在 `ipc/` 等底层通道之上
+- 可依赖：[`lib/osal`](../../lib/osal)、[`lib/include/core`](../../lib/include/core)、`lib/include/sync`、[`lib/ipc`](../../lib/ipc/)
 - 禁止直接依赖：[`lib/drivers`](../../lib/drivers)（由实现侧适配层解耦，避免服务层绑定具体总线实现）
-### 8) [`lib/drivers`](../../lib/drivers)（驱动与 PAL）
+### 9) [`lib/drivers`](../../lib/drivers)（驱动与 PAL）
 - 含义：设备模型、外设驱动、平台适配层（PAL），面向可复用/可移植
 - 边界：驱动层应保持硬件无关抽象；板级差异通过 PAL 接口交由 `bsp`/`platform` 处理
-- 可依赖：[`lib/include/core`](../../lib/include/core)、`lib/include/sync`、[`lib/osal`](../../lib/osal)、必要的 `third_party`（尽量通过 BSP 或 port 封装）
+- 可依赖：[`lib/include/core`](../../lib/include/core)、`lib/include/sync`、[`lib/ipc`](../../lib/ipc/)、[`lib/osal`](../../lib/osal)、必要的 `third_party`（尽量通过 BSP 或 port 封装）
 - 禁止依赖：[`lib/services`](../../lib/services)、[`lib/systems`](../../lib/systems)
 - 规则：禁止直接 include `bsp/` 头文件
 
-### 8.1) `comm adapter`（实现侧适配层，强约束）
+### 9.1) `comm adapter`（实现侧适配层，强约束）
 - 含义：位于实现端的胶水层，用于把具体总线实现（CAN/UART）接入 `services/comm`。
 - 推荐位置：`lib/drivers/src/peripheral/<bus>/comm_adapter_*.c`（按总线分目录）。
 - 允许依赖：[`lib/drivers`](../../lib/drivers) + `lib/services/comm` 公共抽象。
@@ -69,28 +79,29 @@
   - `drivers` 核心路径不得反向依赖 adapter 实现。
   - adapter 仅承担接入与注册，不承载业务协议语义。
 
-### 9) [`lib/systems`](../../lib/systems)（系统模块/业务子系统）
+### 10) [`lib/systems`](../../lib/systems)（系统模块/业务子系统）
 - 含义：机器人系统级模块（chassis/gimbal/robot 等），业务语义明确
-- 可依赖：[`lib/services`](../../lib/services)、[`lib/drivers`](../../lib/drivers)、`lib/include/sync`、[`lib/osal`](../../lib/osal)
+- 可依赖：[`lib/services`](../../lib/services)、[`lib/drivers`](../../lib/drivers)、`lib/include/sync`、[`lib/ipc`](../../lib/ipc/)、[`lib/osal`](../../lib/osal)
 - 说明：可直接依赖 [`lib/drivers`](../../lib/drivers)（驱动层视为硬件无关抽象），必要时可绕过 services
 
-### 10) `test/`（测试应用）
+### 11) `test/`（测试应用）
 - 含义：验证某个模块接口的最小应用
 - 可依赖：所有对外 API（但应避免直接包含端口私有实现）
-- 当前阶段（架构早期、跨平台构建刚搭起）：优先做“接口一致性验证”。行为测试可等 BSP 与样例稳定后，再在板级或 HIL 环境引入。
+- 当前阶段（架构早期、跨平台构建刚搭起）：优先做"接口一致性验证"。行为测试可等 BSP 与样例稳定后，再在板级或 HIL 环境引入。
 ## 依赖方向（强约束）
 允许依赖方向（从上到下，可跨层直连）：
-- `systems` → `services` → `sync` → `osal` → `core` → `third_party`
-- `systems` → `drivers` → `sync` → `osal` → `core` → `third_party`
-- `comm adapter(impl)` → `services/comm` + `drivers` + `sync/osal/core`
-- `bsp` → `drivers/core/third_party`（但不应依赖 `services/systems/osal/sync`）
+- `systems` → `services` → `ipc` → `sync` → `osal` → `core` → `third_party`
+- `systems` → `drivers` → `ipc` → `sync` → `osal` → `core` → `third_party`
+- `comm adapter(impl)` → `services/comm` + `drivers` + `ipc/sync/osal/core`
+- `bsp` → `drivers/core/third_party`（但不应依赖 `services/systems/osal/sync/ipc`）
 - `platform` → `core/third_party`（端口实现不应依赖上层业务）
 
 禁止依赖方向（示例）：
 - `drivers(core)` → `services`（层级倒置）
 - `services(core)` → `drivers`（服务层绑定具体总线实现）
-- `osal` → `services/systems/drivers`（OSAL 必须保持最小集）
-- `bsp` → `osal/sync`（板级层应保持 OS 语义无关）
+- `osal` → `services/systems/drivers/ipc`（OSAL 必须保持最小集）
+- `ipc` → `services/systems/drivers`（IPC 只依赖 OSAL/core）
+- `bsp` → `osal/sync/ipc`（板级层应保持 OS 语义无关）
 - `core` → 任何上层模块（core 应保持基础库属性）
 
 ## 依赖与 include 边界规则
@@ -99,15 +110,16 @@
 - 同层之间不得形成环依赖；必要时拆分子层或抽象接口
 
 ## 聚合目标约定
-- `oh-my-robot`：可裁剪聚合目标，链接 core/osal/sync/drivers/third_party
+- `oh-my-robot`：可裁剪聚合目标，链接 core/osal/sync/ipc/drivers/third_party
 - `om_full`：完整聚合目标，在 `oh-my-robot` 基础上包含 services/systems
 ## 落地检查清单（Review 用）
 - 是否出现 `drivers(core)` include `services/...`
 - 是否出现 `services(core)` include `drivers/...`
-- 是否出现 `bsp` include `osal/...` 或 `sync/...`
+- 是否出现 `bsp` include `osal/...` 或 `sync/...` 或 `ipc/...`
 - 是否出现公共头文件通过相对路径穿透到 `third_party/`
 - 公共头文件是否暴露 third_party 类型/宏
 - OSAL 是否只包含最小原语，且端口实现是否隔离第三方依赖
+- `ipc` 是否只依赖 OSAL/core，未绑定 services/drivers/systems
 - `platform` 是否避免依赖 `services/systems`
 - `core` 是否仅包含基础能力，未引入 OS/驱动/业务语义
 - `drivers` 是否直接 include `bsp/` 头文件
@@ -115,9 +127,8 @@
 - `sync` 是否只依赖 OSAL/core（默认实现），端口加速是否封装良好且后端选择符合约束
 
 ## 头文件聚合入口规范
-为降低上层使用成本，可保留“聚合头”作为对外入口，但需明确边界：
+为降低上层使用成本，可保留"聚合头"作为对外入口，但需明确边界：
 1. 对外入口（应用层/样例/测试）可包含聚合头（如 `awlib.h`、`osal/osal.h`）。
 2. 框架内部实现应优先包含最小必需头文件，避免依赖聚合头形成隐式耦合。
-3. 聚合头内容应受控扩展，不得成为“全局大头文件”。
+3. 聚合头内容应受控扩展，不得成为"全局大头文件"。
 4. 若出现 clangd `unused-includes` 提示，内部实现应按最小依赖原则清理；对外入口可忽略提示。
-

--- a/lib/include/core/om_def.h
+++ b/lib/include/core/om_def.h
@@ -46,6 +46,7 @@ typedef enum
     OM_ERROR_PARAM,       // 参数错误
     OM_ERROR_NULL,        // 参数为NULL
     OM_ERROR_BUSY,        // 忙错误
+    OM_ERROR_WOULD_BLOCK, // 非阻塞条件不满足
     OM_ERROR_EMPTY,       // 空转错误
     OM_ERROR_NOT_SUPPORT, // 不支持的操作
 } OmRet;

--- a/lib/ipc/docs/pipe/pipe_design.md
+++ b/lib/ipc/docs/pipe/pipe_design.md
@@ -1,0 +1,206 @@
+# Pipe 设计决策与正确性分析
+
+本文档记录 Pipe 的核心设计约束、关键决策理由及边界场景分析，供维护者理解"为什么这样设计"而非仅仅"怎样使用"。
+
+Pipe 位于 `lib/ipc/`（跨上下文数据传输层），不属于 `lib/sync/`（纯同步信号层）。详见 [ADR-0009](../../../../docs/adr/0009-ipc_layer_and_pipe_migration.md)。
+
+---
+
+## 1. 架构概览
+
+Pipe 是基于 **Ringbuf + 双二值信号量（门铃模式）** 的单向字节流管道，严格遵循 **SPSC** 并发模型。
+
+```
+┌──────────────────────────────────────────────────┐
+│                      Pipe                        │
+│  ┌──────────────┐    ┌──────────┐    ┌─────────┐│
+│  │  write_sem   │    │ Ringbuf  │    │read_sem ││
+│  │ max=1 init=1 │    │          │    │max=1    ││
+│  │              │    │ buf[]    │    │init=0   ││
+│  └──────┬───────┘    └────┬─────┘    └────┬────┘│
+│         │                 │               │      │
+│    写者 wait 被唤醒   数据进出环        读者 wait │
+│    读者 post 通知       buf            写者 post │
+└──────────────────────────────────────────────────┘
+```
+
+- **write_sem**（`max=1, init=1`）：初始时 pipe 为空，空间可用，写者可直接写入。读者在满→非满转换点 post 通知写者"空间可用"。
+- **read_sem**（`max=1, init=0`）：初始时 pipe 为空，无数据可读。写者在空→非空转换点 post 通知读者"数据到达"。
+
+## 2. 设计决策
+
+### 2.1 为什么选信号量而非 Completion
+
+Completion 底层基于二值信号量 + 一次性状态机（INIT→WAIT→DONE→INIT），其设计目标是"完成通知"语义。Pipe 需要"流式通知"语义，两者不匹配：
+
+- **DONE 状态残留**：写者 done 后，若读者通过 `pipe_read` 的非阻塞路径读到数据（未走 wait 路径），DONE 状态残留，下次 wait 立即返回但 pipe 可能已空——虚假唤醒。
+- **连续 done 返回 BUSY**：写者连续写入间读者未 wait，第二次 done 返回 BUSY，调用方必须静默忽略，违背 Completion 的设计契约。
+- **状态机临界区冗余**：Completion 的 wait/done 内部有 irq_lock 临界区 + 状态判断，SPSC Pipe 下 ringbuf 已通过 Acquire/Release 内存序保证一致性，无需额外临界区。
+- **单等待者检查冗余**：Completion 的 waitThread 字段在 SPSC 下完全多余。
+
+直接使用信号量的优势：
+
+- 无状态机开销，post/wait 直接映射到 OSAL（`osal_sem_post` / `osal_sem_wait`）。
+- 天然支持反复 wait/post 循环，无需重置。
+- 门铃模式天然适配流式场景（见 2.3）。
+
+### 2.2 为什么用双信号量而非单信号量
+
+单信号量只能通知读端"数据到达"，写端满时无法被唤醒。Pipe 存在两个独立的等待条件：
+
+- **写者需要"空间可用"通知**（`write_sem`）：pipe 从满→非满时，由读者 post。
+- **读者需要"数据到达"通知**（`read_sem`）：pipe 从空→非空时，由写者 post。
+
+一个信号量无法同时服务两个方向的阻塞。初始计数值的设计也经过考量：
+
+- `write_sem` init=1：pipe 初始为空，写者可以直接写入（空间可用），无需等待。
+- `read_sem` init=0：pipe 初始为空，读者必须等待数据到达。
+
+这样避免了初始化后写者的首次写入就被迫阻塞。
+
+### 2.3 为什么是门铃模式而非计数模式
+
+门铃模式：仅在**状态转换点** post（空→非空 post `read_sem`；满→非满 post `write_sem`），而非每次操作都 post。
+
+如果每次写都 post `read_sem`，信号量计数会与实际数据量脱节：
+
+- 二值信号量 `max_count=1`，写者写 3 次但读者还没来，信号量最多 post 1 次就满，后续 post 被丢弃（`osal_sem_post` 在计数已满时返回 `OSAL_NO_RESOURCE`）。
+- ringbuf 的原子读写指针才是数据量的唯一真实来源。
+- 信号量只负责"敲门"，不负责"数数"。
+
+---
+
+## 3. API 设计
+
+### 3.1 生命周期管理
+
+Pipe 提供两种构造方式以适应不同场景：
+
+| 函数 | 缓冲区来源 | 适用场景 |
+|---|---|---|
+| `pipe_init` | 外部提供静态缓冲区 | 无动态内存分配的固件、裸机 |
+| `pipe_alloc` | 内部动态分配 | 需要灵活容量、有 `malloc` 支持 |
+
+对应的析构函数 `pipe_deinit` / `pipe_free` 回收信号量及缓冲区，调用前必须确保无并发访问和无等待者。
+
+### 3.2 阻塞超时与 ISR 安全
+
+读写操作按上下文分为两组：
+
+| 上下文 | 写操作 | 消费读 | 窥视读 | 跳过 |
+|---|---|---|---|---|
+| **Task（可阻塞）** | `pipe_write` | `pipe_read` | `pipe_peek` | `pipe_skip` |
+| **ISR（非阻塞）** | `pipe_write_from_isr` | `pipe_read_from_isr` | `pipe_peek_from_isr` | `pipe_skip_from_isr` |
+
+**阻塞机制**：
+
+- 第一次尝试直接操作 ringbuf，成功则立即返回（快速路径）。
+- 若 ringbuf 满/空（写入/读取 0 字节），进入等待路径：
+  - `timeout_ms == 0`：非阻塞模式，立即返回 `OM_ERROR_WOULD_BLOCK`。
+  - `timeout_ms == OSAL_WAIT_FOREVER`：无限等待直到被对端 post 唤醒。
+  - 其他值：阻塞等待指定毫秒数，超时返回 `OM_ERROR_TIMEOUT`。
+- 被唤醒后**重新检查 ringbuf 状态并再次操作**（防御性：门铃模式下 post 只保证"曾经"有状态变化）。
+
+**ISR 安全检查**：阻塞函数内部调用 `osal_is_in_isr()`，若检测到在 ISR 上下文调用则直接返回 `OM_ERROR_PARAM`，防止硬实时破坏。
+
+### 3.3 peek + skip 组合
+
+`pipe_peek` / `pipe_peek_from_isr` 窥视数据但不移动读指针（使用 `ringbuf_out_peek`），数据保留在 pipe 中。`pipe_skip` / `pipe_skip_from_isr` 移动读指针但不拷贝数据（使用 `ringbuf_update_out`）。
+
+典型协议解析场景：
+
+```c
+// 1. 先 peek 帧头判断帧长度
+pipe_peek(&p, header, 4, timeout);
+uint16_t frame_len = decode_length(header);
+
+// 2. 再 peek 整帧数据
+pipe_peek(&p, frame_buf, frame_len, timeout);
+
+// 3. skip 消费整帧（仅移动指针，不拷贝）
+pipe_skip(&p, frame_len);
+```
+
+**设计要点**：
+
+- `peek` **不 post `write_sem`**：peek 不消费数据，pipe 的空间状态不变，无需通知写端。
+- `skip` 在 pipe 从满→非满时 **post `write_sem`**：skip 消费数据后空间被释放，需要通知写端。
+- 相比 `read` + 外部缓冲区回退方案，peek+skip 减少了一次数据拷贝。
+
+### 3.4 状态查询（inline）
+
+`pipe_len`、`pipe_avail`、`pipe_cap`、`pipe_is_empty`、`pipe_is_full` 均为 inline 函数，直接读取 ringbuf 的原子变量，零系统调用开销。在热路径上（如写者每次写前检查 `pipe_avail`）避免函数调用开销。
+
+---
+
+## 4. 并发正确性
+
+### 4.1 ISR 写 + Task 读仍是 SPSC
+
+并发模型看的是"角色数量"而非"上下文数量"。ISR 是唯一的写者，Task 是唯一的读者，各自只扮演一个角色，因此是 SPSC。
+
+同理，ISR 读 + Task 写也是 SPSC。`pipe_read_from_isr` / `pipe_peek_from_isr` / `pipe_skip_from_isr` 的引入使得 Pipe 可以用于 Task 写→ISR 收的数据流向。
+
+### 4.2 门铃模式不会导致死锁
+
+写者流程：`ringbuf_in()` → 检查 `was_empty` → `osal_sem_post(read_sem)`
+读者流程：`ringbuf_out()` 返回 0 → `osal_sem_wait(read_sem)`
+
+关键时序分析：如果写者 `ringbuf_in` 之后、`osal_sem_post(read_sem)` 之前，读者恰好检查到 ringbuf 为空然后进入 wait，不会死锁：
+
+- `ringbuf_in` 使用 Release 语义（`OM_STORE_REL`）发布 `writePos`。
+- `ringbuf_is_empty` 使用 Acquire 语义（`OM_LOAD_ACQ`）读取 `writePos`。
+- 若读者看到空，说明写者尚未完成 `in` 的 Release 写入。
+- 写者完成 `in` 后一定会 post `read_sem`。
+- 时序上：要么读者先看到数据直接读走（不进入 wait），要么读者先进入 wait 然后被写者的 post 唤醒。
+
+写者侧同理：`ringbuf_out` → 检查 `was_full` → `osal_sem_post(write_sem)`，读者进入 wait 的时序窗口同理安全。
+
+### 4.3 阻塞等待被唤醒后必须重新检查 ringbuf
+
+`pipe_write` 满→`osal_sem_wait(write_sem)`→被唤醒→`ringbuf_in`：
+
+被唤醒后必须重新检查 ringbuf 状态并重新执行写入，因为信号量是门铃模式，post 只保证"曾经有过空间"，不保证"此刻还有空间"。SPSC 下不会出现被唤醒后仍无空间的场景（消费者是唯一的读角色，不会抢占我们的写入空间），但代码做防御性编程。
+
+### 4.4 SPSC 无锁的优势
+
+SPSC 模型下，ringbuf 的 Acquire/Release 内存序足以保证数据一致性，不需要任何临界区或互斥锁。这是 Pipe 性能优势的根源。若扩展为 MPSC：
+
+- 写端需要临界区保护（`osal_irq_lock_task` / `osal_irq_lock_from_isr`）。
+- 引入中断延迟和优先级反转风险。
+- 此时应考虑是否用 `osal_queue` 替代。
+
+---
+
+## 5. 边界场景
+
+### 5.1 capacity 必须为 2 的幂
+
+继承自底层 ringbuf 的约束：ringbuf 用 `pos & mask` 代替 `pos % capacity`，要求 capacity 为 2 的幂以支持位运算取模优化。`pipe_init` 通过 `ringbuf_init` 内部校验，`pipe_alloc` 通过 `pipe_is_power_of_two` 显式校验。
+
+### 5.2 ISR 写满返回 WOULD_BLOCK
+
+`pipe_write_from_isr` 在 pipe 满时立即返回 `OM_ERROR_WOULD_BLOCK`。ISR 中不能阻塞，这不是 Pipe 的缺陷，而是 ISR 场景的设计约束。应对策略由使用者决定：增大缓冲区、提高读者/Task 优先级、使用 DMA 双缓冲等。
+
+### 5.3 信号量 post 失败静默忽略
+
+在门铃模式下，若 `osal_sem_post` 因为信号量计数值已满（`max_count=1`）而返回 `OSAL_NO_RESOURCE`（如连续两次空→非空的 post 之间读者没有 wait），Pipe 静默忽略此返回值。
+
+这是正确的行为：门铃不负责计数，上一个 post 已足够唤醒对端。对端被唤醒后通过 ringbuf 的原子指针获取真实数据量——不会漏掉数据。
+
+### 5.4 写入/消费 0 字节
+
+当 ringbuf_in/out 返回 0 时，代表空/满状态，此时不 post 任何信号量（因为没有发生状态转换）。状态转换的判定依据是操作前的 `was_empty` / `was_full` 标志，而非操作后的实际字节数。
+
+---
+
+## 6. 核心设计约束总结
+
+Pipe 的核心设计约束是 **SPSC + 门铃模式**：
+
+- **SPSC** 让我们不需要锁，ringbuf 的 Acquire/Release 内存序即足够。
+- **门铃模式** 让信号量只负责唤醒不负责计数，避免了计数与数据量脱节的问题。
+- **数据量的真实来源** 始终是 ringbuf 的原子读写指针，信号量仅做辅助。
+- 这两个约束互相支撑：正因为是 SPSC，ringbuf 的 Acquire/Release 内存序就够了，无需临界区；正因为信号量不计数，我们才不需要担心 post 被丢弃导致计数错误。
+
+所有新增功能（ISR 读端操作、peek/skip、生命周期管理）都在此核心约束框架内扩展，保持了设计的一致性和简洁性。

--- a/lib/ipc/include/ipc/README.md
+++ b/lib/ipc/include/ipc/README.md
@@ -1,0 +1,24 @@
+# ipc
+
+跨上下文数据传输层（Inter-Context Communication）。提供任务间、ISR 与任务间的字节流/消息传输通道，与 `sync/`（纯同步信号）及 `services/comm/`（结构化消息）互补。
+
+## 层定位
+
+| 层 | 职责 | 数据载荷 |
+|---|---|---|
+| `sync/` | 纯同步信号（completion、event、barrier...） | 无 |
+| **`ipc/`** | **跨上下文数据通道（pipe、channel...）** | **有（字节流/类型化消息）** |
+| `services/comm/` | 结构化消息通信（帧格式、路由、发布订阅） | 有（带协议头） |
+
+## 设计约束
+
+- 依赖：core + osal（通过信号量/队列等 OSAL 原语组合实现）
+- 不依赖：services / drivers / systems
+- 支持通信方：Task ↔ Task、ISR → Task、Task → ISR（通过 `_from_isr` 变体）
+- 核间通信为 future scope
+
+## 模块
+
+| 模块 | 文件 | 说明 |
+|---|---|---|
+| pipe | `include/ipc/pipe.h` `src/pipe.c` | SPSC 字节流管道（Ringbuf + 门铃信号量） |

--- a/lib/ipc/include/ipc/pipe.h
+++ b/lib/ipc/include/ipc/pipe.h
@@ -1,0 +1,193 @@
+#ifndef OM_IPC_PIPE_H
+#define OM_IPC_PIPE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "core/data_struct/ringbuffer.h"
+#include "core/om_def.h"
+#include "osal/osal_sem.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief 单向点对点字节流管道（SPSC）
+ *
+ * 基于 Ringbuf + 双二值信号量的门铃模式实现：
+ * - read_sem：写者 post 通知读者数据到达（pipe 从空→非空时触发）
+ * - write_sem：读者 post 通知写者空间可用（pipe 从满→非满时触发）
+ *
+ * 并发约束：严格 SPSC，禁止多写者或多读者同时操作。
+ * 适用场景：Task↔Task、ISR→Task、Task→ISR 的字节流传输。
+ */
+typedef struct Pipe {
+    Ringbuf  rb;        /* 底层环形缓冲区 */
+    OsalSem* read_sem;  /* 可读通知信号量（max=1, init=0） */
+    OsalSem* write_sem; /* 可写通知信号量（max=1, init=1） */
+} Pipe;
+
+/**
+ * @brief 使用静态缓冲区初始化 Pipe
+ * @param pipe   Pipe 实例指针
+ * @param buf    外部提供的缓冲区，大小须 >= capacity 字节
+ * @param capacity 缓冲区容量，必须为 2 的幂且 > 0
+ * @return `OM_OK` 成功；`OM_ERROR_PARAM` 参数非法；`OM_ERROR_MEMORY` 信号量创建失败
+ * @note 禁止在 ISR 中调用
+ */
+OmRet pipe_init(Pipe* pipe, uint8_t* buf, unsigned int capacity);
+
+/**
+ * @brief 动态分配缓冲区创建 Pipe
+ * @param pipe     Pipe 实例指针
+ * @param capacity 缓冲区容量，必须为 2 的幂且 > 0
+ * @param pmalloc  内存分配函数，传 NULL 时回退到标准库 malloc
+ * @return `OM_OK` 成功；`OM_ERROR_PARAM` 参数非法；`OM_ERROR_MEMORY` 分配或信号量创建失败
+ * @note 禁止在 ISR 中调用
+ */
+OmRet pipe_alloc(Pipe* pipe, unsigned int capacity, void* (*pmalloc)(size_t));
+
+/**
+ * @brief 销毁使用 pipe_init 创建的 Pipe
+ * @param pipe Pipe 实例指针
+ * @note 禁止在 ISR 中调用
+ * @note 调用方需确保无并发访问和无等待者
+ */
+void pipe_deinit(Pipe* pipe);
+
+/**
+ * @brief 销毁使用 pipe_alloc 创建的 Pipe 并释放缓冲区
+ * @param pipe  Pipe 实例指针
+ * @param pfree 内存释放函数，传 NULL 时回退到标准库 free
+ * @note 禁止在 ISR 中调用
+ * @note 调用方需确保无并发访问和无等待者
+ */
+void pipe_free(Pipe* pipe, void (*pfree)(void*));
+
+/**
+ * @brief 向 Pipe 写入字节数据（阻塞超时）
+ * @param pipe       Pipe 实例指针
+ * @param data       待写入数据指针
+ * @param len        待写入字节数
+ * @param timeout_ms 超时时间（ms），0 表示非阻塞，OSAL_WAIT_FOREVER 表示无限等待
+ * @return >= 0 实际写入字节数；< 0 错误码（OM_ERROR_WOULD_BLOCK / OM_ERROR_TIMEOUT / OM_ERROR_PARAM）
+ * @note 禁止在 ISR 中调用，请使用 pipe_write_from_isr
+ * @note SPSC：同一时刻仅允许一个写者
+ */
+int pipe_write(Pipe* pipe, const void* data, int len, uint32_t timeout_ms);
+
+/**
+ * @brief 向 Pipe 写入字节数据（ISR 安全，非阻塞）
+ * @param pipe Pipe 实例指针
+ * @param data 待写入数据指针
+ * @param len  待写入字节数
+ * @return >= 0 实际写入字节数；< 0 错误码（OM_ERROR_WOULD_BLOCK / OM_ERROR_PARAM）
+ * @note 仅允许在 ISR 中调用
+ * @note SPSC：同一时刻仅允许一个写者
+ */
+int pipe_write_from_isr(Pipe* pipe, const void* data, int len);
+
+/**
+ * @brief 从 Pipe 读取字节数据（消费式，阻塞超时）
+ * @param pipe       Pipe 实例指针
+ * @param buf        输出缓冲区
+ * @param len        期望读取的最大字节数
+ * @param timeout_ms 超时时间（ms），0 表示非阻塞，OSAL_WAIT_FOREVER 表示无限等待
+ * @return >= 0 实际读取字节数；< 0 错误码（OM_ERROR_WOULD_BLOCK / OM_ERROR_TIMEOUT / OM_ERROR_PARAM）
+ * @note 禁止在 ISR 中调用
+ * @note SPSC：同一时刻仅允许一个读者
+ */
+int pipe_read(Pipe* pipe, void* buf, int len, uint32_t timeout_ms);
+
+/**
+ * @brief 从 Pipe 窥视字节数据（非消费式，阻塞超时）
+ * @param pipe       Pipe 实例指针
+ * @param buf        输出缓冲区
+ * @param len        期望窥视的最大字节数
+ * @param timeout_ms 超时时间（ms），0 表示非阻塞，OSAL_WAIT_FOREVER 表示无限等待
+ * @return >= 0 实际窥视字节数；< 0 错误码（OM_ERROR_WOULD_BLOCK / OM_ERROR_TIMEOUT / OM_ERROR_PARAM）
+ * @note 禁止在 ISR 中调用
+ * @note 窥视后数据保留在 Pipe 中，需配合 pipe_skip 消费
+ */
+int pipe_peek(Pipe* pipe, void* buf, int len, uint32_t timeout_ms);
+
+/**
+ * @brief 跳过 Pipe 中的数据（移动读指针，不拷贝）
+ * @param pipe Pipe 实例指针
+ * @param len  期望跳过的最大字节数
+ * @return `OM_OK` 至少跳过了 1 字节；`OM_ERROR_EMPTY` Pipe 为空；`OM_ERROR_PARAM` 参数非法
+ * @note 禁止在 ISR 中调用，请使用 pipe_skip_from_isr
+ */
+OmRet pipe_skip(Pipe* pipe, int len);
+
+/**
+ * @brief 从 Pipe 读取字节数据（ISR 安全，非阻塞，消费式）
+ * @param pipe Pipe 实例指针
+ * @param buf  输出缓冲区
+ * @param len  期望读取的最大字节数
+ * @return >= 0 实际读取字节数；< 0 错误码（OM_ERROR_WOULD_BLOCK / OM_ERROR_PARAM）
+ * @note 仅允许在 ISR 中调用
+ * @note 非阻塞：Pipe 为空时返回 `OM_ERROR_WOULD_BLOCK`
+ * @note 读取后若 Pipe 从满变为非满，通过 `osal_sem_post_from_isr` 通知写端
+ * @note SPSC：同一时刻仅允许一个读者
+ */
+int pipe_read_from_isr(Pipe* pipe, void* buf, int len);
+
+/**
+ * @brief 从 Pipe 窥视字节数据（ISR 安全，非阻塞，非消费式）
+ * @param pipe Pipe 实例指针
+ * @param buf  输出缓冲区
+ * @param len  期望窥视的最大字节数
+ * @return >= 0 实际窥视字节数；< 0 错误码（OM_ERROR_WOULD_BLOCK / OM_ERROR_PARAM）
+ * @note 仅允许在 ISR 中调用
+ * @note 非阻塞：Pipe 为空时返回 `OM_ERROR_WOULD_BLOCK`
+ * @note 窥视后数据保留在 Pipe 中，需配合 pipe_skip_from_isr 消费
+ * @note SPSC：同一时刻仅允许一个读者
+ */
+int pipe_peek_from_isr(Pipe* pipe, void* buf, int len);
+
+/**
+ * @brief 跳过 Pipe 中的数据（ISR 安全，非阻塞，移动读指针不拷贝）
+ * @param pipe Pipe 实例指针
+ * @param len  期望跳过的最大字节数
+ * @return `OM_OK` 至少跳过了 1 字节；`OM_ERROR_EMPTY` Pipe 为空；`OM_ERROR_PARAM` 参数非法
+ * @note 仅允许在 ISR 中调用
+ * @note 跳过成功后若 Pipe 从满变为非满，通过 `osal_sem_post_from_isr` 通知写端
+ * @note SPSC：同一时刻仅允许一个读者
+ */
+OmRet pipe_skip_from_isr(Pipe* pipe, int len);
+
+/* ---- 状态查询（inline，零系统调用开销） ---- */
+
+static inline int pipe_len(Pipe* pipe)
+{
+    return (int)ringbuf_len(&pipe->rb);
+}
+
+static inline int pipe_avail(Pipe* pipe)
+{
+    return (int)ringbuf_avail(&pipe->rb);
+}
+
+static inline int pipe_cap(Pipe* pipe)
+{
+    return (int)ringbuf_cap(&pipe->rb);
+}
+
+static inline bool pipe_is_empty(Pipe* pipe)
+{
+    return ringbuf_is_empty(&pipe->rb);
+}
+
+static inline bool pipe_is_full(Pipe* pipe)
+{
+    return ringbuf_is_full(&pipe->rb);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OM_IPC_PIPE_H */

--- a/lib/ipc/src/pipe.c
+++ b/lib/ipc/src/pipe.c
@@ -1,0 +1,294 @@
+#include "ipc/pipe.h"
+
+#include "osal/osal_core.h"
+#include <string.h>
+
+static OmRet pipe_create_sems(Pipe* pipe)
+{
+    if (osal_sem_create(&pipe->read_sem, 1u, 0u) != OSAL_OK)
+        return OM_ERROR_MEMORY;
+
+    if (osal_sem_create(&pipe->write_sem, 1u, 1u) != OSAL_OK)
+    {
+        osal_sem_delete(pipe->read_sem);
+        pipe->read_sem = NULL;
+        return OM_ERROR_MEMORY;
+    }
+    return OM_OK;
+}
+
+static bool pipe_is_power_of_two(unsigned int v)
+{
+    return v != 0u && (v & (v - 1u)) == 0u;
+}
+
+OmRet pipe_init(Pipe* pipe, uint8_t* buf, unsigned int capacity)
+{
+    if (!pipe)
+        return OM_ERROR_PARAM;
+
+    memset(pipe, 0, sizeof(*pipe));
+
+    if (!ringbuf_init(&pipe->rb, buf, 1u, capacity))
+        return OM_ERROR_PARAM;
+
+    OmRet ret = pipe_create_sems(pipe);
+    if (ret != OM_OK)
+    {
+        memset(&pipe->rb, 0, sizeof(pipe->rb));
+        return ret;
+    }
+
+    return OM_OK;
+}
+
+OmRet pipe_alloc(Pipe* pipe, unsigned int capacity, void* (*pmalloc)(size_t))
+{
+    if (!pipe || !pipe_is_power_of_two(capacity))
+        return OM_ERROR_PARAM;
+
+    memset(pipe, 0, sizeof(*pipe));
+
+    if (!ringbuf_alloc(&pipe->rb, 1u, capacity, pmalloc))
+        return OM_ERROR_MEMORY;
+
+    OmRet ret = pipe_create_sems(pipe);
+    if (ret != OM_OK)
+    {
+        free_ringbuf(&pipe->rb, NULL);
+        memset(&pipe->rb, 0, sizeof(pipe->rb));
+        return ret;
+    }
+
+    return OM_OK;
+}
+
+void pipe_deinit(Pipe* pipe)
+{
+    if (!pipe)
+        return;
+
+    if (pipe->read_sem)
+    {
+        osal_sem_delete(pipe->read_sem);
+        pipe->read_sem = NULL;
+    }
+    if (pipe->write_sem)
+    {
+        osal_sem_delete(pipe->write_sem);
+        pipe->write_sem = NULL;
+    }
+
+    memset(&pipe->rb, 0, sizeof(pipe->rb));
+}
+
+void pipe_free(Pipe* pipe, void (*pfree)(void*))
+{
+    if (!pipe)
+        return;
+
+    if (pipe->read_sem)
+    {
+        osal_sem_delete(pipe->read_sem);
+        pipe->read_sem = NULL;
+    }
+    if (pipe->write_sem)
+    {
+        osal_sem_delete(pipe->write_sem);
+        pipe->write_sem = NULL;
+    }
+
+    free_ringbuf(&pipe->rb, pfree);
+    memset(&pipe->rb, 0, sizeof(pipe->rb));
+}
+
+int pipe_write(Pipe* pipe, const void* data, int len, uint32_t timeout_ms)
+{
+    if (!pipe || !data || len <= 0)
+        return OM_ERROR_PARAM;
+
+    if (osal_is_in_isr())
+        return OM_ERROR_PARAM;
+
+    bool was_empty = ringbuf_is_empty(&pipe->rb);
+    unsigned int n = ringbuf_in(&pipe->rb, data, (unsigned int)len);
+
+    if (n > 0u)
+    {
+        if (was_empty)
+            osal_sem_post(pipe->read_sem);
+        return (int)n;
+    }
+
+    if (timeout_ms == 0u)
+        return OM_ERROR_WOULD_BLOCK;
+
+    OsalStatus ws = osal_sem_wait(pipe->write_sem, timeout_ms);
+    if (ws != OSAL_OK)
+        return (ws == OSAL_WOULD_BLOCK) ? OM_ERROR_WOULD_BLOCK : OM_ERROR_TIMEOUT;
+
+    was_empty = ringbuf_is_empty(&pipe->rb);
+    n = ringbuf_in(&pipe->rb, data, (unsigned int)len);
+    if (n > 0u)
+    {
+        if (was_empty)
+            osal_sem_post(pipe->read_sem);
+        return (int)n;
+    }
+
+    return OM_ERROR_WOULD_BLOCK;
+}
+
+int pipe_write_from_isr(Pipe* pipe, const void* data, int len)
+{
+    if (!pipe || !data || len <= 0)
+        return OM_ERROR_PARAM;
+
+    bool was_empty = ringbuf_is_empty(&pipe->rb);
+    unsigned int n = ringbuf_in(&pipe->rb, data, (unsigned int)len);
+
+    if (n > 0u)
+    {
+        if (was_empty)
+            osal_sem_post_from_isr(pipe->read_sem);
+        return (int)n;
+    }
+
+    return OM_ERROR_WOULD_BLOCK;
+}
+
+int pipe_read(Pipe* pipe, void* buf, int len, uint32_t timeout_ms)
+{
+    if (!pipe || !buf || len <= 0)
+        return OM_ERROR_PARAM;
+
+    if (osal_is_in_isr())
+        return OM_ERROR_PARAM;
+
+    bool was_full = ringbuf_is_full(&pipe->rb);
+    unsigned int n = ringbuf_out(&pipe->rb, buf, (unsigned int)len);
+
+    if (n > 0u)
+    {
+        if (was_full)
+            osal_sem_post(pipe->write_sem);
+        return (int)n;
+    }
+
+    if (timeout_ms == 0u)
+        return OM_ERROR_WOULD_BLOCK;
+
+    OsalStatus ws = osal_sem_wait(pipe->read_sem, timeout_ms);
+    if (ws != OSAL_OK)
+        return (ws == OSAL_WOULD_BLOCK) ? OM_ERROR_WOULD_BLOCK : OM_ERROR_TIMEOUT;
+
+    was_full = ringbuf_is_full(&pipe->rb);
+    n = ringbuf_out(&pipe->rb, buf, (unsigned int)len);
+    if (n > 0u)
+    {
+        if (was_full)
+            osal_sem_post(pipe->write_sem);
+        return (int)n;
+    }
+
+    return OM_ERROR_WOULD_BLOCK;
+}
+
+int pipe_peek(Pipe* pipe, void* buf, int len, uint32_t timeout_ms)
+{
+    if (!pipe || !buf || len <= 0)
+        return OM_ERROR_PARAM;
+
+    if (osal_is_in_isr())
+        return OM_ERROR_PARAM;
+
+    unsigned int n = ringbuf_out_peek(&pipe->rb, buf, (unsigned int)len);
+
+    if (n > 0u)
+        return (int)n;
+
+    if (timeout_ms == 0u)
+        return OM_ERROR_WOULD_BLOCK;
+
+    OsalStatus ws = osal_sem_wait(pipe->read_sem, timeout_ms);
+    if (ws != OSAL_OK)
+        return (ws == OSAL_WOULD_BLOCK) ? OM_ERROR_WOULD_BLOCK : OM_ERROR_TIMEOUT;
+
+    n = ringbuf_out_peek(&pipe->rb, buf, (unsigned int)len);
+    if (n > 0u)
+        return (int)n;
+
+    return OM_ERROR_WOULD_BLOCK;
+}
+
+OmRet pipe_skip(Pipe* pipe, int len)
+{
+    if (!pipe || len <= 0)
+        return OM_ERROR_PARAM;
+
+    if (osal_is_in_isr())
+        return OM_ERROR_PARAM;
+
+    if (ringbuf_is_empty(&pipe->rb))
+        return OM_ERROR_EMPTY;
+
+    bool was_full = ringbuf_is_full(&pipe->rb);
+    unsigned int avail = ringbuf_len(&pipe->rb);
+    unsigned int skip = ((unsigned int)len < avail) ? (unsigned int)len : avail;
+    ringbuf_update_out(&pipe->rb, skip);
+
+    if (was_full && skip > 0u)
+        osal_sem_post(pipe->write_sem);
+
+    return OM_OK;
+}
+
+int pipe_read_from_isr(Pipe* pipe, void* buf, int len)
+{
+    if (!pipe || !buf || len <= 0)
+        return OM_ERROR_PARAM;
+
+    bool was_full = ringbuf_is_full(&pipe->rb);
+    unsigned int n = ringbuf_out(&pipe->rb, buf, (unsigned int)len);
+
+    if (n > 0u)
+    {
+        if (was_full)
+            osal_sem_post_from_isr(pipe->write_sem);
+        return (int)n;
+    }
+
+    return OM_ERROR_WOULD_BLOCK;
+}
+
+int pipe_peek_from_isr(Pipe* pipe, void* buf, int len)
+{
+    if (!pipe || !buf || len <= 0)
+        return OM_ERROR_PARAM;
+
+    unsigned int n = ringbuf_out_peek(&pipe->rb, buf, (unsigned int)len);
+
+    if (n > 0u)
+        return (int)n;
+
+    return OM_ERROR_WOULD_BLOCK;
+}
+
+OmRet pipe_skip_from_isr(Pipe* pipe, int len)
+{
+    if (!pipe || len <= 0)
+        return OM_ERROR_PARAM;
+
+    if (ringbuf_is_empty(&pipe->rb))
+        return OM_ERROR_EMPTY;
+
+    bool was_full = ringbuf_is_full(&pipe->rb);
+    unsigned int avail = ringbuf_len(&pipe->rb);
+    unsigned int skip = ((unsigned int)len < avail) ? (unsigned int)len : avail;
+    ringbuf_update_out(&pipe->rb, skip);
+
+    if (was_full && skip > 0u)
+        osal_sem_post_from_isr(pipe->write_sem);
+
+    return OM_OK;
+}

--- a/lib/sync/include/sync/README.md
+++ b/lib/sync/include/sync/README.md
@@ -1,11 +1,6 @@
-﻿# sync
+# sync
 
-Requirement phase only.
+同步语义层，提供基于 OSAL 原语组合出的纯同步信号抽象（无数据载荷）。
 
-This directory keeps stable sync headers already used by existing code, but
-current work stage does not introduce or freeze new sync APIs.
-
-Active requirement document:
-
-- `oh-my-robot/docs/internal/archive/v0.0.0_features/issue_000_process_docs_migration/sync/sync_requirements_volume.md`
+当前阶段仅保留已完成实现且已有代码引用的稳定头文件，不引入或冻结新的同步 API。
 

--- a/lib/xmake.lua
+++ b/lib/xmake.lua
@@ -1,6 +1,6 @@
-﻿--- @file oh_my_robot/lib/xmake.lua
+--- @file oh_my_robot/lib/xmake.lua
 --- @brief OM lib 子库构建脚本
---- @details 按单一责任原则拆分 core/algorithm/drivers/async/systems 等静态库。
+--- @details 按单一责任原则拆分 core/algorithm/drivers/ipc/async/systems 等静态库。
 
 --- @target tar_awcore
 --- @brief AW 核心静态库
@@ -40,6 +40,16 @@ target("tar_awapi_sync")
     add_includedirs("sync/include", {public = true})
 target_end()
 
+--- @target tar_awapi_ipc
+--- @brief IPC API 头文件接口
+--- @details 为跨上下文数据传输层提供公共头文件。
+target("tar_awapi_ipc")
+    set_kind("headeronly")
+    add_deps("tar_awcore", {public = true})
+    add_deps("tar_awapi_osal", {public = true})
+    add_includedirs("ipc/include", {public = true})
+target_end()
+
 --- @target tar_awapi_async
 --- @brief Async API 头文件接口
 --- @details 为异步执行基座提供公共头文件与基础依赖。
@@ -48,6 +58,7 @@ target("tar_awapi_async")
     add_deps("tar_awcore", {public = true})
     add_deps("tar_awapi_osal", {public = true})
     add_deps("tar_awapi_sync", {public = true})
+    add_deps("tar_awapi_ipc", {public = true})
     add_includedirs("async/include", {public = true})
 target_end()
 
@@ -60,6 +71,7 @@ target("tar_awapi_driver")
     add_includedirs("drivers/include", {public = true})
     add_deps("tar_awapi_osal", {public = true})
     add_deps("tar_awapi_sync", {public = true})
+    add_deps("tar_awapi_ipc", {public = true})
 target_end()
 
 --- @target tar_awalgo

--- a/platform/ipc/xmake.lua
+++ b/platform/ipc/xmake.lua
@@ -1,0 +1,19 @@
+--- @file oh_my_robot/platform/ipc/xmake.lua
+--- @brief IPC 构建脚本
+--- @details 负责跨上下文数据传输通道的编译注入。
+
+local ipc_root = os.scriptdir()
+local lib_root = path.join(ipc_root, "..", "..", "lib")
+local ipc_source_glob = path.join(lib_root, "ipc", "src", "*.c")
+
+--- @target tar_ipc
+--- @brief IPC 静态库
+--- @details 注入跨上下文数据通道实现。
+target("tar_ipc")
+    set_kind("static")
+    add_deps("tar_awapi_ipc", {public = true})
+    add_deps("tar_awcore", {public = true})
+    add_deps("tar_osal", {public = true})
+    add_rules("oh_my_robot.context")
+    add_files(ipc_source_glob)
+target_end()

--- a/samples/ipc/pipe/main.c
+++ b/samples/ipc/pipe/main.c
@@ -1,0 +1,452 @@
+/**
+ * @file main.c
+ * @brief IPC Pipe 单向管道独立例程
+ * @details
+ * 本例程覆盖 Pipe 的基础合同与流式传输场景。
+ * - 组1：参数校验（NULL 指针、非法容量、ISR 上下文守卫）
+ * - 组2：生命周期（init/deinit、alloc/free）
+ * - 组3：基础写入与读取（消费式、窥视、跳过）
+ * - 组4：阻塞超时（write 满阻塞、read 空阻塞、超时返回）
+ * - 组5：非阻塞模式（WOULD_BLOCK 语义）
+ * - 组6：Task→Task 流式传输（写者线程 + 读者线程，验证数据完整性）
+ * - 组7：线程模拟 ISR 写入（高优先级写者 + 阻塞读者，验证 from_isr 路径）
+ * - 判定标准：`g_result.done == 1` 且 `g_result.failed == 0`
+ */
+#include "core/om_def.h"
+#include "osal/osal.h"
+#include "ipc/pipe.h"
+
+/* ---- 用户宏配置 ---- */
+
+#ifndef PIPE_TEST_BUF_CAPACITY
+#define PIPE_TEST_BUF_CAPACITY 64u
+#endif
+
+#ifndef PIPE_TEST_STRESS_ROUNDS
+#define PIPE_TEST_STRESS_ROUNDS 2000u
+#endif
+
+#ifndef PIPE_TEST_STRESS_PAYLOAD_LEN
+#define PIPE_TEST_STRESS_PAYLOAD_LEN 7u
+#endif
+
+#ifndef PIPE_TEST_ISR_STRESS_ROUNDS
+#define PIPE_TEST_ISR_STRESS_ROUNDS 500u
+#endif
+
+/* ---- 测试基础设施 ---- */
+
+typedef struct {
+    volatile uint32_t total;
+    volatile uint32_t failed;
+    volatile uint32_t done;
+} PipeTestResult;
+
+static PipeTestResult g_result = {0u, 0u, 0u};
+static OsalThread* g_test_thread = NULL;
+
+static void pipe_expect(int condition)
+{
+    g_result.total++;
+    if (!condition)
+        g_result.failed++;
+}
+
+/* ---- 测试用全局资源 ---- */
+
+static Pipe g_pipe = {{0}, NULL, NULL};
+static uint8_t g_pipe_buf[PIPE_TEST_BUF_CAPACITY] = {0};
+
+/* ---- 组6：Task→Task 流式传输 ---- */
+
+static volatile uint32_t g_writer_done = 0u;
+static volatile uint32_t g_reader_done = 0u;
+static volatile uint32_t g_writer_ok = 0u;
+static volatile uint32_t g_reader_ok = 0u;
+static volatile uint32_t g_writer_err = 0u;
+static volatile uint32_t g_reader_err = 0u;
+static OsalThread* g_writer_thread = NULL;
+static OsalThread* g_reader_thread = NULL;
+
+static void pipe_writer_thread_entry(void* arg)
+{
+    (void)arg;
+    uint32_t round = 0u;
+    uint8_t payload[PIPE_TEST_STRESS_PAYLOAD_LEN];
+
+    for (round = 0u; round < PIPE_TEST_STRESS_ROUNDS; round++) {
+        uint32_t i;
+        for (i = 0u; i < PIPE_TEST_STRESS_PAYLOAD_LEN; i++)
+            payload[i] = (uint8_t)(round + i);
+
+        int n = pipe_write(&g_pipe, payload, (int)PIPE_TEST_STRESS_PAYLOAD_LEN, OSAL_WAIT_FOREVER);
+        if (n == (int)PIPE_TEST_STRESS_PAYLOAD_LEN)
+            g_writer_ok++;
+        else
+            g_writer_err++;
+    }
+
+    g_writer_done = 1u;
+    osal_thread_exit();
+}
+
+static void pipe_reader_thread_entry(void* arg)
+{
+    (void)arg;
+    uint32_t round = 0u;
+    uint8_t expected[PIPE_TEST_STRESS_PAYLOAD_LEN];
+    uint8_t actual[PIPE_TEST_STRESS_PAYLOAD_LEN];
+
+    for (round = 0u; round < PIPE_TEST_STRESS_ROUNDS; round++) {
+        uint32_t i;
+        int n = pipe_read(&g_pipe, actual, (int)PIPE_TEST_STRESS_PAYLOAD_LEN, OSAL_WAIT_FOREVER);
+        if (n != (int)PIPE_TEST_STRESS_PAYLOAD_LEN) {
+            g_reader_err++;
+            continue;
+        }
+
+        for (i = 0u; i < PIPE_TEST_STRESS_PAYLOAD_LEN; i++)
+            expected[i] = (uint8_t)(round + i);
+
+        int match = 1;
+        for (i = 0u; i < PIPE_TEST_STRESS_PAYLOAD_LEN; i++) {
+            if (actual[i] != expected[i]) {
+                match = 0;
+                break;
+            }
+        }
+
+        if (match)
+            g_reader_ok++;
+        else
+            g_reader_err++;
+    }
+
+    g_reader_done = 1u;
+    osal_thread_exit();
+}
+
+/* ---- 组7：线程模拟 ISR 写入 ---- */
+
+static volatile uint32_t g_isr_writer_done = 0u;
+static volatile uint32_t g_isr_writer_ok = 0u;
+static volatile uint32_t g_isr_writer_would_block = 0u;
+static volatile uint32_t g_isr_reader_done = 0u;
+static volatile uint32_t g_isr_reader_ok = 0u;
+static volatile uint32_t g_isr_reader_err = 0u;
+static OsalThread* g_isr_writer_thread = NULL;
+static OsalThread* g_isr_reader_thread = NULL;
+
+static void pipe_isr_writer_thread_entry(void* arg)
+{
+    (void)arg;
+    uint32_t round = 0u;
+    uint8_t payload[4];
+
+    for (round = 0u; round < PIPE_TEST_ISR_STRESS_ROUNDS; round++) {
+        payload[0] = (uint8_t)(round);
+        payload[1] = (uint8_t)(round >> 8u);
+        payload[2] = (uint8_t)(round >> 16u);
+        payload[3] = (uint8_t)(round >> 24u);
+
+        int n = pipe_write_from_isr(&g_pipe, payload, 4);
+        if (n > 0)
+            g_isr_writer_ok++;
+        else if (n == OM_ERROR_WOULD_BLOCK)
+            g_isr_writer_would_block++;
+
+        if ((round & 0x00FFu) == 0u)
+            (void)osal_sleep_ms(1u);
+    }
+
+    g_isr_writer_done = 1u;
+    osal_thread_exit();
+}
+
+static void pipe_isr_reader_thread_entry(void* arg)
+{
+    (void)arg;
+    uint32_t total_read = 0u;
+
+    while (total_read < PIPE_TEST_ISR_STRESS_ROUNDS) {
+        uint8_t buf[4];
+        int n = pipe_read(&g_pipe, buf, 4, 100u);
+        if (n == 4) {
+            g_isr_reader_ok++;
+            total_read++;
+        } else if (n < 0 && n != OM_ERROR_WOULD_BLOCK && n != OM_ERROR_TIMEOUT) {
+            g_isr_reader_err++;
+            break;
+        }
+
+        if (g_isr_writer_done && pipe_is_empty(&g_pipe))
+            break;
+    }
+
+    g_isr_reader_done = 1u;
+    osal_thread_exit();
+}
+
+/* ---- 辅助：等待标志位 ---- */
+
+static int pipe_wait_flag(volatile uint32_t* flag, uint32_t timeout_ms)
+{
+    OsalTimeMs start = osal_time_now_monotonic();
+    OsalTimeMs deadline = start + timeout_ms;
+
+    while (*flag == 0u) {
+        if (!osal_time_before(osal_time_now_monotonic(), deadline))
+            return 0;
+        (void)osal_sleep_ms(1u);
+    }
+    return 1;
+}
+
+/* ---- 测试主线程 ---- */
+
+static void pipe_test_thread_entry(void* arg)
+{
+    uint8_t test_buf[16];
+    uint8_t verify_buf[16];
+    uint32_t i;
+
+    (void)arg;
+
+    /* ---- 组1：参数校验 ---- */
+
+    pipe_expect(pipe_init(NULL, g_pipe_buf, PIPE_TEST_BUF_CAPACITY) == OM_ERROR_PARAM);
+    pipe_expect(pipe_init(&g_pipe, NULL, PIPE_TEST_BUF_CAPACITY) == OM_ERROR_PARAM);
+    pipe_expect(pipe_init(&g_pipe, g_pipe_buf, 0u) == OM_ERROR_PARAM);
+    pipe_expect(pipe_init(&g_pipe, g_pipe_buf, 3u) == OM_ERROR_PARAM);
+    pipe_expect(pipe_alloc(NULL, PIPE_TEST_BUF_CAPACITY, NULL) == OM_ERROR_PARAM);
+    pipe_expect(pipe_alloc(&g_pipe, 0u, NULL) == OM_ERROR_PARAM);
+    pipe_expect(pipe_write(NULL, "x", 1, 0u) == OM_ERROR_PARAM);
+    pipe_expect(pipe_write(&g_pipe, NULL, 1, 0u) == OM_ERROR_PARAM);
+    pipe_expect(pipe_write(&g_pipe, "x", 0, 0u) == OM_ERROR_PARAM);
+    pipe_expect(pipe_write_from_isr(NULL, "x", 1) == OM_ERROR_PARAM);
+    pipe_expect(pipe_read(NULL, test_buf, 1, 0u) == OM_ERROR_PARAM);
+    pipe_expect(pipe_read(&g_pipe, NULL, 1, 0u) == OM_ERROR_PARAM);
+    pipe_expect(pipe_peek(NULL, test_buf, 1, 0u) == OM_ERROR_PARAM);
+    pipe_expect(pipe_skip(NULL, 1) == OM_ERROR_PARAM);
+    pipe_expect(pipe_skip(&g_pipe, 0) == OM_ERROR_PARAM);
+
+    /* ---- 组2：生命周期 ---- */
+
+    pipe_expect(pipe_init(&g_pipe, g_pipe_buf, PIPE_TEST_BUF_CAPACITY) == OM_OK);
+    pipe_expect(pipe_is_empty(&g_pipe));
+    pipe_expect(!pipe_is_full(&g_pipe));
+    pipe_expect(pipe_len(&g_pipe) == 0);
+    pipe_expect(pipe_cap(&g_pipe) == (int)PIPE_TEST_BUF_CAPACITY);
+    pipe_expect(pipe_avail(&g_pipe) == (int)PIPE_TEST_BUF_CAPACITY);
+    pipe_deinit(&g_pipe);
+
+    {
+        Pipe alloc_pipe = {{0}, NULL, NULL};
+        OmRet ret = pipe_alloc(&alloc_pipe, 64u, NULL);
+        pipe_expect(ret == OM_OK);
+        if (ret == OM_OK)
+            pipe_free(&alloc_pipe, NULL);
+    }
+
+    /* ---- 组3：基础写入与读取 ---- */
+
+    pipe_expect(pipe_init(&g_pipe, g_pipe_buf, PIPE_TEST_BUF_CAPACITY) == OM_OK);
+
+    for (i = 0u; i < 16u; i++)
+        test_buf[i] = (uint8_t)i;
+
+    {
+        int n = pipe_write(&g_pipe, test_buf, 16, 0u);
+        pipe_expect(n == 16);
+        pipe_expect(!pipe_is_empty(&g_pipe));
+        pipe_expect(pipe_len(&g_pipe) == 16);
+    }
+
+    {
+        int n = pipe_peek(&g_pipe, verify_buf, 16, 0u);
+        pipe_expect(n == 16);
+        pipe_expect(pipe_len(&g_pipe) == 16);
+        {
+            int match = 1;
+            for (i = 0u; i < 16u; i++) {
+                if (verify_buf[i] != (uint8_t)i) { match = 0; break; }
+            }
+            pipe_expect(match);
+        }
+    }
+
+    {
+        int n = pipe_read(&g_pipe, verify_buf, 8, 0u);
+        pipe_expect(n == 8);
+        pipe_expect(pipe_len(&g_pipe) == 8);
+        {
+            int match = 1;
+            for (i = 0u; i < 8u; i++) {
+                if (verify_buf[i] != (uint8_t)i) { match = 0; break; }
+            }
+            pipe_expect(match);
+        }
+    }
+
+    {
+        OmRet ret = pipe_skip(&g_pipe, 8);
+        pipe_expect(ret == OM_OK);
+        pipe_expect(pipe_is_empty(&g_pipe));
+    }
+
+    {
+        OmRet ret = pipe_skip(&g_pipe, 1);
+        pipe_expect(ret == OM_ERROR_EMPTY);
+    }
+
+    pipe_deinit(&g_pipe);
+
+    /* ---- 组4：阻塞超时 ---- */
+
+    pipe_expect(pipe_init(&g_pipe, g_pipe_buf, PIPE_TEST_BUF_CAPACITY) == OM_OK);
+
+    {
+        int n = pipe_read(&g_pipe, verify_buf, 1, 10u);
+        pipe_expect(n == OM_ERROR_TIMEOUT);
+    }
+
+    {
+        while (pipe_avail(&g_pipe) > 0) {
+            int n = pipe_write(&g_pipe, test_buf, 1, 0u);
+            if (n <= 0) break;
+        }
+        pipe_expect(pipe_is_full(&g_pipe));
+
+        {
+            int n = pipe_write(&g_pipe, test_buf, 1, 10u);
+            pipe_expect(n == OM_ERROR_TIMEOUT);
+        }
+    }
+
+    pipe_deinit(&g_pipe);
+
+    /* ---- 组5：非阻塞模式 ---- */
+
+    pipe_expect(pipe_init(&g_pipe, g_pipe_buf, PIPE_TEST_BUF_CAPACITY) == OM_OK);
+
+    {
+        int n = pipe_read(&g_pipe, verify_buf, 1, 0u);
+        pipe_expect(n == OM_ERROR_WOULD_BLOCK);
+    }
+
+    {
+        while (pipe_avail(&g_pipe) > 0) {
+            int n = pipe_write(&g_pipe, test_buf, 1, 0u);
+            if (n <= 0) break;
+        }
+        {
+            int n = pipe_write(&g_pipe, test_buf, 1, 0u);
+            pipe_expect(n == OM_ERROR_WOULD_BLOCK);
+        }
+    }
+
+    {
+        int n = pipe_write_from_isr(&g_pipe, test_buf, 1);
+        pipe_expect(n == OM_ERROR_WOULD_BLOCK);
+    }
+
+    pipe_deinit(&g_pipe);
+
+    /* ---- 组6：Task→Task 流式传输 ---- */
+
+    {
+        OsalThreadAttr writer_attr = {
+            "pipe_writer",
+            512u * OSAL_STACK_WORD_BYTES,
+            2u,
+        };
+        OsalThreadAttr reader_attr = {
+            "pipe_reader",
+            512u * OSAL_STACK_WORD_BYTES,
+            2u,
+        };
+
+        g_writer_done = 0u;
+        g_reader_done = 0u;
+        g_writer_ok = 0u;
+        g_reader_ok = 0u;
+        g_writer_err = 0u;
+        g_reader_err = 0u;
+
+        pipe_expect(pipe_init(&g_pipe, g_pipe_buf, PIPE_TEST_BUF_CAPACITY) == OM_OK);
+
+        pipe_expect(osal_thread_create(&g_writer_thread, &writer_attr, pipe_writer_thread_entry, NULL) == OSAL_OK);
+        pipe_expect(osal_thread_create(&g_reader_thread, &reader_attr, pipe_reader_thread_entry, NULL) == OSAL_OK);
+
+        pipe_expect(pipe_wait_flag(&g_writer_done, 30000u) == 1);
+        pipe_expect(pipe_wait_flag(&g_reader_done, 30000u) == 1);
+
+        pipe_expect(g_writer_err == 0u);
+        pipe_expect(g_reader_err == 0u);
+        pipe_expect(g_writer_ok == PIPE_TEST_STRESS_ROUNDS);
+        pipe_expect(g_reader_ok == PIPE_TEST_STRESS_ROUNDS);
+
+        g_writer_thread = NULL;
+        g_reader_thread = NULL;
+        pipe_deinit(&g_pipe);
+    }
+
+    /* ---- 组7：线程模拟 ISR 写入 ---- */
+
+    {
+        OsalThreadAttr isr_writer_attr = {
+            "pipe_isr_w",
+            512u * OSAL_STACK_WORD_BYTES,
+            OSAL_PRIORITY_MAX > 0u ? OSAL_PRIORITY_MAX - 1u : 0u,
+        };
+        OsalThreadAttr isr_reader_attr = {
+            "pipe_isr_r",
+            512u * OSAL_STACK_WORD_BYTES,
+            2u,
+        };
+
+        g_isr_writer_done = 0u;
+        g_isr_reader_done = 0u;
+        g_isr_writer_ok = 0u;
+        g_isr_writer_would_block = 0u;
+        g_isr_reader_ok = 0u;
+        g_isr_reader_err = 0u;
+
+        pipe_expect(pipe_init(&g_pipe, g_pipe_buf, PIPE_TEST_BUF_CAPACITY) == OM_OK);
+
+        pipe_expect(osal_thread_create(&g_isr_reader_thread, &isr_reader_attr, pipe_isr_reader_thread_entry, NULL) == OSAL_OK);
+        (void)osal_sleep_ms(10u);
+        pipe_expect(osal_thread_create(&g_isr_writer_thread, &isr_writer_attr, pipe_isr_writer_thread_entry, NULL) == OSAL_OK);
+
+        pipe_expect(pipe_wait_flag(&g_isr_writer_done, 30000u) == 1);
+        pipe_expect(pipe_wait_flag(&g_isr_reader_done, 30000u) == 1);
+
+        pipe_expect(g_isr_reader_err == 0u);
+        pipe_expect(g_isr_reader_ok > 0u);
+        pipe_expect(g_isr_writer_ok > 0u);
+
+        g_isr_writer_thread = NULL;
+        g_isr_reader_thread = NULL;
+        pipe_deinit(&g_pipe);
+    }
+
+    /* ---- 测试结束 ---- */
+
+    g_result.done = 1u;
+    for (;;)
+        (void)osal_sleep_ms(1000u);
+}
+
+int main(void)
+{
+    OsalThreadAttr test_attr = {
+        "pipe_test",
+        768u * OSAL_STACK_WORD_BYTES,
+        2u,
+    };
+
+    if (osal_thread_create(&g_test_thread, &test_attr, pipe_test_thread_entry, NULL) != OSAL_OK)
+        return -1;
+
+    return osal_kernel_start();
+}


### PR DESCRIPTION
## 🎯 修改目的


新建 `lib/ipc/` 跨上下文数据传输层（Inter-Context Communication），将 Pipe 从 `lib/sync/` 迁移至此，并补充完整构建体系、示例代码与架构文档。

### 背景

- `sync/` 现有 Completion（纯同步信号，无数据载荷）与 Pipe（带数据载荷的传输通道），二者语义不同
- Pipe 本质是**跨上下文数据通道**（Task ↔ Task / ISR → Task / Task → ISR），与 Completion 的"完成通知"语义不匹配
- 按"通信机制建目录、通信方作为 API 变体（`_from_isr` 后缀）"原则建立新层
- 详见 [ADR-0009](docs/adr/0009-ipc_layer_and_pipe_migration.md)


## 🧩 涉及的框架维度

- [x] **系统与机制** (OSAL, Sync, IPC, Middleware，Service等)
- [x] **文档或示例** (Sample 演示代码, Docs)
- [x] **构建与基建** (XMake 工程配置, 编译脚本等)


## 🔄 变更类型

- [x] ✨ 新特性 (新建 IPC 层，新增 Pipe 通信原语)
- [x] 📝 文档更新 (ADR-0009、层依赖规范、Pipe 设计文档)
- [x] 🔧 配置变更 (lib/xmake.lua、build/xmake.lua、platform/ipc/xmake.lua)
- [x] 🔄 其他变更 (Pipe 从 sync/ 迁移至 ipc/，头文件守卫更新)


## 📁 变更文件 (12 files, +1289 / -42)

### 新增

| 文件 | 说明 |
|---|---|
| `lib/ipc/include/ipc/pipe.h` | Pipe 头文件（`OM_IPC_PIPE_H`） |
| `lib/ipc/src/pipe.c` | Pipe 实现（Ringbuf + 双信号量门铃模式） |
| `lib/ipc/docs/pipe/pipe_design.md` | Pipe 设计决策与正确性分析 |
| `lib/ipc/include/ipc/README.md` | IPC 层定位、职责边界、模块清单 |
| `platform/ipc/xmake.lua` | `tar_ipc` 静态库构建目标 |
| `samples/ipc/pipe/main.c` | Pipe 示例（含 7 组测试：参数校验、生命周期、读写、超时、WOULD_BLOCK、Task↔Task 流式、模拟 ISR） |
| `docs/adr/0009-ipc_layer_and_pipe_migration.md` | IPC 层创建决策记录 |

### 修改

| 文件 | 说明 |
|---|---|
| `lib/xmake.lua` | 新增 `tar_awapi_ipc`（headeronly 目标），注入 `tar_awapi_async` 和 `tar_awapi_driver` 依赖链 |
| `build/xmake.lua` | 新增 `includes("../platform/ipc")` 和 `tar_ipc` 聚合依赖 |
| `docs/architecture/layer_dependency_spec.md` | 新增 IPC 层定义（§7）、更新依赖方向含 ipc、补充检查清单 |
| `lib/include/core/om_def.h` | 新增 `OM_ERROR_WOULD_BLOCK` 错误码（Pipe 非阻塞语义依赖） |
| `lib/sync/include/sync/README.md` | 标注 Pipe 已迁移至 `lib/ipc/`，添加 ADR-0009 引用 |


## 🏗️ 新架构分层

```
sync     → 纯同步信号（completion，无数据载荷）
ipc      → 跨上下文数据通道（pipe，有数据载荷）    ← 本次新建
services/comm → 结构化消息通信（future，构建在 ipc 之上）
```

依赖方向：`systems → services → ipc → sync → osal → core`


## 🛠️ 测试验证说明

- [x] armclang + FreeRTOS 编译通过
- [x] 示例代码 `samples/ipc/pipe/main.c` 覆盖 7 组场景：参数校验、生命周期（init/alloc/deinit/free）、基础读写（consumer/peek/skip）、阻塞超时（满阻塞/空阻塞/超时返回）、非阻塞模式（WOULD_BLOCK）、Task↔Task 流式传输（2000 轮验证数据完整性）、高优先级线程模拟 ISR 写入（500 轮）
- [x] 未运行板级测试（MCU 硬件环境暂不可用）


## ⚠️ 影响范围分析

- 是否修改了现有的对外 API 接口？👉 **是** — Pipe 的 `#include` 路径从 `sync/pipe.h` 变更为 `ipc/pipe.h`；头文件守卫从 `OM_SYNC_PIPE_H` 变更为 `OM_IPC_PIPE_H`；API 函数签名不变。
- 是否修改了现有的对外数据结构？👉 **否** — `Pipe` 结构体定义不变；`om_def.h` 仅新增枚举值 `OM_ERROR_WOULD_BLOCK`，不影响已有值的语义。


## 🔗 Issue 关联

```
Refs #（待创建 Issue 后补充编号）
```


## ✅ 提交者自查清单

- [x] 代码风格符合团队统一规范，变量/函数命名语义清晰。
- [x] 核心复杂逻辑（无锁 ringbuf + 门铃信号量、死锁时序分析）已在设计文档中添加充分中文注释。
- [x] 本地分支已基于最新的 `upstream/integration` 变基，`git rev-list --left-right --count upstream/integration...HEAD` 输出 `0 1`。
- [x] 本次提交序列已按单一职责拆分（一个 commit：IPC 层创建 + Pipe 迁移 + 构建体系 + 文档更新）。
- [x] 提交信息符合 `类型(作用域): 简短描述` 规范：`feat(ipc): 创建 IPC 跨上下文数据传输层并迁移 Pipe`。
- [x] 未夹带无关注释、空行或排版改动。