### PR TITLE
refactor(atomic): rename memory order macros AW_MO_* to MO_*

### DIFF
--- a/docs/architecture/architecture_reference_manual.md
+++ b/docs/architecture/architecture_reference_manual.md
@@ -180,12 +180,12 @@
 #### [`oh-my-robot/lib/include/atomic/atomic_base.h`](../../lib/include/atomic/atomic_base.h)
 - 外部宏
   - `AW_USE_STDATOMIC`
-  - `AW_MO_RELAXED`
-  - `AW_MO_CONSUME`
-  - `AW_MO_ACQUIRE`
-  - `AW_MO_RELEASE`
-  - `AW_MO_ACQ_REL`
-  - `AW_MO_SEQ_CST`
+  - `MO_RELAXED`
+  - `MO_CONSUME`
+  - `MO_ACQUIRE`
+  - `MO_RELEASE`
+  - `MO_ACQ_REL`
+  - `MO_SEQ_CST`
   - `om_atomic_t`
   - `AW_ATOMIC_VAR_INIT`
   - `AW_INLINE`

--- a/lib/include/atomic/README.md
+++ b/lib/include/atomic/README.md
@@ -53,12 +53,12 @@
 
 #### 2.1.1 内存序枚举 (`om_memory_order`)
 
-- `AW_MO_RELAXED`: 无同步语义。
-- `AW_MO_CONSUME`: 消费语义。
-- `AW_MO_ACQUIRE`: 获取语义。
-- `AW_MO_RELEASE`: 释放语义。
-- `AW_MO_ACQ_REL`: 获取+释放语义。
-- `AW_MO_SEQ_CST`: 顺序一致性（全屏障）。
+- `MO_RELAXED`: 无同步语义。
+- `MO_CONSUME`: 消费语义。
+- `MO_ACQUIRE`: 获取语义。
+- `MO_RELEASE`: 释放语义。
+- `MO_ACQ_REL`: 获取+释放语义。
+- `MO_SEQ_CST`: 顺序一致性（全屏障）。
 
 #### 2.1.2 基础读写
 
@@ -128,7 +128,7 @@
 - `om_fence_rel()`: 释放屏障。
 - `om_fence_ar()`: 获取释放屏障。
 - `om_fence_seq()`: 全局顺序一致性屏障。
-- `om_compiler_barrier()`: 编译器屏障（通过 `om_signal_fence(AW_MO_ACQ_REL)` 实现）。
+- `om_compiler_barrier()`: 编译器屏障（通过 `om_signal_fence(MO_ACQ_REL)` 实现）。
 
 ------
 

--- a/lib/include/atomic/atomic.h
+++ b/lib/include/atomic/atomic.h
@@ -258,9 +258,9 @@ extern "C"
 #define om_thread_fence(order)                                                                                                             \
     do                                                                                                                                     \
     {                                                                                                                                      \
-        if ((order) == AW_MO_SEQ_CST)                                                                                                      \
+        if ((order) == MO_SEQ_CST)                                                                                                      \
             MemoryBarrier();                                                                                                               \
-        else if ((order) != AW_MO_RELAXED)                                                                                                 \
+        else if ((order) != MO_RELAXED)                                                                                                 \
             _ReadWriteBarrier();                                                                                                           \
     } while (0)
 

--- a/lib/include/atomic/atomic_ac5.h
+++ b/lib/include/atomic/atomic_ac5.h
@@ -11,7 +11,7 @@
 // AC5 Barrier Helpers
 AW_INLINE void _om_ac5_barrier(OmMemoryOrder order)
 {
-    if (order != AW_MO_RELAXED)
+    if (order != MO_RELAXED)
     {
         __sync_synchronize(); // AC5 Full Barrier
     }
@@ -34,7 +34,7 @@ AW_INLINE void _om_ac5_barrier(OmMemoryOrder order)
     {                                                                                                                                      \
         _om_ac5_barrier(order);                                                                                                            \
         *(volatile __typeof__(*(ptr))*)(ptr) = (val);                                                                                      \
-        if (order == AW_MO_SEQ_CST)                                                                                                        \
+        if (order == MO_SEQ_CST)                                                                                                        \
             __sync_synchronize();                                                                                                          \
     } while (0)
 
@@ -81,7 +81,7 @@ AW_INLINE void _om_ac5_barrier(OmMemoryOrder order)
 
 // 6. Fences
 #define _om_impl_thread_fence(order)                                                                                                       \
-    if (order != AW_MO_RELAXED)                                                                                                            \
+    if (order != MO_RELAXED)                                                                                                            \
     __sync_synchronize()
 
 #define _om_impl_signal_fence(order) __schedule_barrier()

--- a/lib/include/atomic/atomic_base.h
+++ b/lib/include/atomic/atomic_base.h
@@ -45,24 +45,24 @@
 typedef memory_order OmMemoryOrder;
 
 // 映射宏常量
-#define AW_MO_RELAXED memory_order_relaxed
-#define AW_MO_CONSUME memory_order_consume
-#define AW_MO_ACQUIRE memory_order_acquire
-#define AW_MO_RELEASE memory_order_release
-#define AW_MO_ACQ_REL memory_order_acq_rel
-#define AW_MO_SEQ_CST memory_order_seq_cst
+#define MO_RELAXED memory_order_relaxed
+#define MO_CONSUME memory_order_consume
+#define MO_ACQUIRE memory_order_acquire
+#define MO_RELEASE memory_order_release
+#define MO_ACQ_REL memory_order_acq_rel
+#define MO_SEQ_CST memory_order_seq_cst
 
 #else
 // --- 传统/回退模式 ---
 // 定义与 C11 类似的枚举，供特定编译器的实现使用
 typedef enum
 {
-    AW_MO_RELAXED = 0,
-    AW_MO_CONSUME = 1,
-    AW_MO_ACQUIRE = 2,
-    AW_MO_RELEASE = 3,
-    AW_MO_ACQ_REL = 4,
-    AW_MO_SEQ_CST = 5
+    MO_RELAXED = 0,
+    MO_CONSUME = 1,
+    MO_ACQUIRE = 2,
+    MO_RELEASE = 3,
+    MO_ACQ_REL = 4,
+    MO_SEQ_CST = 5
 } OmMemoryOrder;
 
 #endif

--- a/lib/include/atomic/atomic_msvc.h
+++ b/lib/include/atomic/atomic_msvc.h
@@ -10,16 +10,16 @@
 // ----------------------------------------------------------------------------
 AW_INLINE void _om_msvc_barrier_pre(OmMemoryOrder order)
 {
-    if (order != AW_MO_RELAXED)
+    if (order != MO_RELAXED)
         _ReadWriteBarrier(); // Compiler barrier
-    if (order == AW_MO_SEQ_CST)
+    if (order == MO_SEQ_CST)
         MemoryBarrier(); // Full hardware barrier
 }
 AW_INLINE void _om_msvc_barrier_post(OmMemoryOrder order)
 {
-    if (order != AW_MO_RELAXED)
+    if (order != MO_RELAXED)
         _ReadWriteBarrier();
-    if (order == AW_MO_SEQ_CST)
+    if (order == MO_SEQ_CST)
         MemoryBarrier();
 }
 
@@ -36,7 +36,7 @@ AW_INLINE void _om_msvc_store_8(volatile char* ptr, char val, OmMemoryOrder orde
 {
     _om_msvc_barrier_pre(order);
     *ptr = val;
-    if (order == AW_MO_SEQ_CST)
+    if (order == MO_SEQ_CST)
         MemoryBarrier();
 }
 AW_INLINE char _om_msvc_exchange_8(volatile char* ptr, char val, OmMemoryOrder order)
@@ -82,7 +82,7 @@ AW_INLINE void _om_msvc_store_16(volatile short* ptr, short val, OmMemoryOrder o
 {
     _om_msvc_barrier_pre(order);
     *ptr = val;
-    if (order == AW_MO_SEQ_CST)
+    if (order == MO_SEQ_CST)
         MemoryBarrier();
 }
 AW_INLINE short _om_msvc_exchange_16(volatile short* ptr, short val, OmMemoryOrder order)
@@ -128,7 +128,7 @@ AW_INLINE void _om_msvc_store_32(volatile long* ptr, long val, OmMemoryOrder ord
 {
     _om_msvc_barrier_pre(order);
     *ptr = val;
-    if (order == AW_MO_SEQ_CST)
+    if (order == MO_SEQ_CST)
         MemoryBarrier();
 }
 AW_INLINE long _om_msvc_exchange_32(volatile long* ptr, long val, OmMemoryOrder order)
@@ -174,7 +174,7 @@ AW_INLINE void _om_msvc_store_64(volatile long long* ptr, long long val, OmMemor
 {
     _om_msvc_barrier_pre(order);
     *ptr = val;
-    if (order == AW_MO_SEQ_CST)
+    if (order == MO_SEQ_CST)
         MemoryBarrier();
 }
 AW_INLINE long long _om_msvc_exchange_64(volatile long long* ptr, long long val, OmMemoryOrder order)

--- a/lib/include/atomic/atomic_simple.h
+++ b/lib/include/atomic/atomic_simple.h
@@ -26,39 +26,39 @@ extern "C"
 // ============================================================================
 
 // 最常用的同步读取，保证后续读写不越过此点
-#define OM_LOAD_ACQ(ptr) om_load(ptr, AW_MO_ACQUIRE)
+#define OM_LOAD_ACQ(ptr) om_load(ptr, MO_ACQUIRE)
 
 // 仅保证原子读取，无顺序保证 (常用于统计计数读取)
-#define OM_LOAD_RLX(ptr) om_load(ptr, AW_MO_RELAXED)
+#define OM_LOAD_RLX(ptr) om_load(ptr, MO_RELAXED)
 
 // 消费语义 (在某些架构上比 Acquire 轻量，但通常等同于 Acquire)
-#define OM_LOAD_CONSUME(ptr) om_load(ptr, AW_MO_CONSUME)
+#define OM_LOAD_CONSUME(ptr) om_load(ptr, MO_CONSUME)
 
 // ============================================================================
 // 2. Store (写入)
 // ============================================================================
 
 // 最常用的同步写入，保证之前的读写已完成 (常用于发布数据)
-#define OM_STORE_REL(ptr, val) om_store(ptr, val, AW_MO_RELEASE)
+#define OM_STORE_REL(ptr, val) om_store(ptr, val, MO_RELEASE)
 
 // 仅保证原子写入 (常用于重置计数器)
-#define OM_STORE_RLX(ptr, val) om_store(ptr, val, AW_MO_RELAXED)
+#define OM_STORE_RLX(ptr, val) om_store(ptr, val, MO_RELAXED)
 
 // ============================================================================
 // 3. Exchange (交换 / Swap)
 // ============================================================================
 
 // 强同步交换 (常用于锁的获取与释放)
-#define OM_SWAP_AR(ptr, val) om_exchange(ptr, val, AW_MO_ACQ_REL)
+#define OM_SWAP_AR(ptr, val) om_exchange(ptr, val, MO_ACQ_REL)
 
 // 获取语义交换 (常用于获取锁)
-#define OM_SWAP_ACQ(ptr, val) om_exchange(ptr, val, AW_MO_ACQUIRE)
+#define OM_SWAP_ACQ(ptr, val) om_exchange(ptr, val, MO_ACQUIRE)
 
 // 释放语义交换 (常用于释放锁并写入新值)
-#define OM_SWAP_REL(ptr, val) om_exchange(ptr, val, AW_MO_RELEASE)
+#define OM_SWAP_REL(ptr, val) om_exchange(ptr, val, MO_RELEASE)
 
 // 松散交换
-#define OM_SWAP_RLX(ptr, val) om_exchange(ptr, val, AW_MO_RELAXED)
+#define OM_SWAP_RLX(ptr, val) om_exchange(ptr, val, MO_RELAXED)
 
 // ============================================================================
 // 4. CAS (Compare And Swap)
@@ -67,32 +67,32 @@ extern "C"
 // 本库中 CAS 失败时的内存序默认设置为 Acquire (如果成功序包含Acquire) 或 Relaxed
 
 // [最常用] 强 CAS，成功时全屏障，失败时获取最新值 (适用于大多数无锁结构)
-#define OM_CAS_AR(ptr, exp_ptr, des) om_cas(ptr, exp_ptr, des, AW_MO_ACQ_REL, AW_MO_ACQUIRE)
+#define OM_CAS_AR(ptr, exp_ptr, des) om_cas(ptr, exp_ptr, des, MO_ACQ_REL, MO_ACQUIRE)
 
 // 获取型 CAS (成功和失败都具备 Acquire 语义)
-#define OM_CAS_ACQ(ptr, exp_ptr, des) om_cas(ptr, exp_ptr, des, AW_MO_ACQUIRE, AW_MO_ACQUIRE)
+#define OM_CAS_ACQ(ptr, exp_ptr, des) om_cas(ptr, exp_ptr, des, MO_ACQUIRE, MO_ACQUIRE)
 
 // 释放型 CAS (成功时 Release，失败时 Relaxed)
-#define OM_CAS_REL(ptr, exp_ptr, des) om_cas(ptr, exp_ptr, des, AW_MO_RELEASE, AW_MO_RELAXED)
+#define OM_CAS_REL(ptr, exp_ptr, des) om_cas(ptr, exp_ptr, des, MO_RELEASE, MO_RELAXED)
 
 // 松散 CAS (无同步语义)
-#define OM_CAS_RLX(ptr, exp_ptr, des) om_cas(ptr, exp_ptr, des, AW_MO_RELAXED, AW_MO_RELAXED)
+#define OM_CAS_RLX(ptr, exp_ptr, des) om_cas(ptr, exp_ptr, des, MO_RELAXED, MO_RELAXED)
 
 // ============================================================================
 // 5. Arithmetic (Fetch Add / Sub)
 // ============================================================================
 
 // --- Fetch Add (返回旧值) ---
-#define OM_FAA_RLX(ptr, val) om_fetch_add(ptr, val, AW_MO_RELAXED)
-#define OM_FAA_ACQ(ptr, val) om_fetch_add(ptr, val, AW_MO_ACQUIRE)
-#define OM_FAA_REL(ptr, val) om_fetch_add(ptr, val, AW_MO_RELEASE)
-#define OM_FAA_AR(ptr, val) om_fetch_add(ptr, val, AW_MO_ACQ_REL)
+#define OM_FAA_RLX(ptr, val) om_fetch_add(ptr, val, MO_RELAXED)
+#define OM_FAA_ACQ(ptr, val) om_fetch_add(ptr, val, MO_ACQUIRE)
+#define OM_FAA_REL(ptr, val) om_fetch_add(ptr, val, MO_RELEASE)
+#define OM_FAA_AR(ptr, val) om_fetch_add(ptr, val, MO_ACQ_REL)
 
 // --- Fetch Sub (返回旧值) ---
-#define OM_FAS_RLX(ptr, val) om_fetch_sub(ptr, val, AW_MO_RELAXED)
-#define OM_FAS_ACQ(ptr, val) om_fetch_sub(ptr, val, AW_MO_ACQUIRE)
-#define OM_FAS_REL(ptr, val) om_fetch_sub(ptr, val, AW_MO_RELEASE)
-#define OM_FAS_AR(ptr, val) om_fetch_sub(ptr, val, AW_MO_ACQ_REL)
+#define OM_FAS_RLX(ptr, val) om_fetch_sub(ptr, val, MO_RELAXED)
+#define OM_FAS_ACQ(ptr, val) om_fetch_sub(ptr, val, MO_ACQUIRE)
+#define OM_FAS_REL(ptr, val) om_fetch_sub(ptr, val, MO_RELEASE)
+#define OM_FAS_AR(ptr, val) om_fetch_sub(ptr, val, MO_ACQ_REL)
 
 // --- Helper: Increment / Decrement (常用操作) ---
 #define OM_INC_RLX(ptr) OM_FAA_RLX(ptr, 1)
@@ -105,35 +105,35 @@ extern "C"
 // ============================================================================
 
 // --- Fetch And (按位与) ---
-#define OM_FAND_RLX(ptr, val) om_fetch_and(ptr, val, AW_MO_RELAXED)
-#define OM_FAND_ACQ(ptr, val) om_fetch_and(ptr, val, AW_MO_ACQUIRE)
-#define OM_FAND_REL(ptr, val) om_fetch_and(ptr, val, AW_MO_RELEASE)
-#define OM_FAND_AR(ptr, val) om_fetch_and(ptr, val, AW_MO_ACQ_REL)
+#define OM_FAND_RLX(ptr, val) om_fetch_and(ptr, val, MO_RELAXED)
+#define OM_FAND_ACQ(ptr, val) om_fetch_and(ptr, val, MO_ACQUIRE)
+#define OM_FAND_REL(ptr, val) om_fetch_and(ptr, val, MO_RELEASE)
+#define OM_FAND_AR(ptr, val) om_fetch_and(ptr, val, MO_ACQ_REL)
 
 // --- Fetch Or (按位或 - 常用于设置标志位) ---
-#define OM_FOR_RLX(ptr, val) om_fetch_or(ptr, val, AW_MO_RELAXED)
-#define OM_FOR_ACQ(ptr, val) om_fetch_or(ptr, val, AW_MO_ACQUIRE)
-#define OM_FOR_REL(ptr, val) om_fetch_or(ptr, val, AW_MO_RELEASE)
-#define OM_FOR_AR(ptr, val) om_fetch_or(ptr, val, AW_MO_ACQ_REL)
+#define OM_FOR_RLX(ptr, val) om_fetch_or(ptr, val, MO_RELAXED)
+#define OM_FOR_ACQ(ptr, val) om_fetch_or(ptr, val, MO_ACQUIRE)
+#define OM_FOR_REL(ptr, val) om_fetch_or(ptr, val, MO_RELEASE)
+#define OM_FOR_AR(ptr, val) om_fetch_or(ptr, val, MO_ACQ_REL)
 
 // --- Fetch Xor (按位异或 - 常用于翻转位) ---
-#define OM_FXOR_RLX(ptr, val) om_fetch_xor(ptr, val, AW_MO_RELAXED)
-#define OM_FXOR_ACQ(ptr, val) om_fetch_xor(ptr, val, AW_MO_ACQUIRE)
-#define OM_FXOR_REL(ptr, val) om_fetch_xor(ptr, val, AW_MO_RELEASE)
-#define OM_FXOR_AR(ptr, val) om_fetch_xor(ptr, val, AW_MO_ACQ_REL)
+#define OM_FXOR_RLX(ptr, val) om_fetch_xor(ptr, val, MO_RELAXED)
+#define OM_FXOR_ACQ(ptr, val) om_fetch_xor(ptr, val, MO_ACQUIRE)
+#define OM_FXOR_REL(ptr, val) om_fetch_xor(ptr, val, MO_RELEASE)
+#define OM_FXOR_AR(ptr, val) om_fetch_xor(ptr, val, MO_ACQ_REL)
 
 // ============================================================================
 // 7. Fences (内存屏障)
 // ============================================================================
 
 // 线程屏障 (全局可见性同步)
-#define OM_FENCE_ACQ() om_thread_fence(AW_MO_ACQUIRE)
-#define OM_FENCE_REL() om_thread_fence(AW_MO_RELEASE)
-#define OM_FENCE_AR() om_thread_fence(AW_MO_ACQ_REL)
-#define OM_FENCE_SEQ() om_thread_fence(AW_MO_SEQ_CST) // 最强屏障
+#define OM_FENCE_ACQ() om_thread_fence(MO_ACQUIRE)
+#define OM_FENCE_REL() om_thread_fence(MO_RELEASE)
+#define OM_FENCE_AR() om_thread_fence(MO_ACQ_REL)
+#define OM_FENCE_SEQ() om_thread_fence(MO_SEQ_CST) // 最强屏障
 
 // 编译器/信号屏障 (防止编译器重排，不生成 CPU 指令)
-#define OM_COMPILER_BARRIER() om_signal_fence(AW_MO_ACQ_REL)
+#define OM_COMPILER_BARRIER() om_signal_fence(MO_ACQ_REL)
 
 #ifdef __cplusplus
 }

--- a/lib/source/data_struct/bitmap.c
+++ b/lib/source/data_struct/bitmap.c
@@ -72,7 +72,7 @@ OmRet om_bitmap_atomic_init(AwBitmapAtomic *bitmap, OmAtomicUlong *buffer, size_
     bitmap->words = buffer;
 
     for (size_t index = 0; index < bitmap->meta.wordCount; index++)
-        OM_STORE(&bitmap->words[index], 0UL, AW_MO_RELAXED);
+        OM_STORE(&bitmap->words[index], 0UL, MO_RELAXED);
     return OM_OK;
 }
 
@@ -118,7 +118,7 @@ bool om_bitmap_atomic_test(const AwBitmapAtomic *bitmap, size_t bit_index)
 
     size_t word_index = om_bitmap_word_index(bit_index);
     unsigned long bit_mask = om_bitmap_bit_mask(bit_index);
-    unsigned long word_value = OM_LOAD(&bitmap->words[word_index], AW_MO_RELAXED);
+    unsigned long word_value = OM_LOAD(&bitmap->words[word_index], MO_RELAXED);
     return (word_value & bit_mask) != 0U;
 }
 
@@ -129,7 +129,7 @@ bool om_bitmap_atomic_try_set(AwBitmapAtomic *bitmap, size_t bit_index)
 
     size_t word_index = om_bitmap_word_index(bit_index);
     unsigned long bit_mask = om_bitmap_bit_mask(bit_index);
-    unsigned long old_value = OM_FETCH_OR(&bitmap->words[word_index], bit_mask, AW_MO_ACQ_REL);
+    unsigned long old_value = OM_FETCH_OR(&bitmap->words[word_index], bit_mask, MO_ACQ_REL);
     return (old_value & bit_mask) == 0U;
 }
 
@@ -140,7 +140,7 @@ void om_bitmap_atomic_clear(AwBitmapAtomic *bitmap, size_t bit_index)
 
     size_t word_index = om_bitmap_word_index(bit_index);
     unsigned long bit_mask = om_bitmap_bit_mask(bit_index);
-    OM_FETCH_AND(&bitmap->words[word_index], ~bit_mask, AW_MO_ACQ_REL);
+    OM_FETCH_AND(&bitmap->words[word_index], ~bit_mask, MO_ACQ_REL);
 }
 
 OmRet om_bitmap_atomic_alloc_first_zero(AwBitmapAtomic *bitmap, size_t start_hint, size_t *bit_out)


### PR DESCRIPTION
## 🎯 修改目的

将 atomic 库的内存序宏/枚举从 `AW_MO_*` 重命名为 `MO_*`，移除 `AW_` 前缀，使命名更简洁。

## 🧩 涉及的框架维度 (可多选)

- [ ] **硬件与驱动** (BSP, Driver等)
- [ ] **系统与机制** (OSAL, Sync, Async、Middleware，Service等)
- [x] **数据结构与算法** (通用数据结构, 通用算法库等)
- [x] **文档或示例** (Sample 演示代码, Docs)
- [ ] **构建与基建** (XMake 工程配置, 编译脚本等)
- [ ] **应用与服务** (app模板, 应用层服务等)

## 🔄 变更类型
- [ ] 🐛 Bug 修复
- [ ] ✨ 新特性
- [x] ♻️ 代码重构 (优化代码结构，不改变对外接口行为)
- [ ] 📝 文档更新
- [ ] 🔧 配置变更
- [ ] 🔨 工具变更
- [ ] 🔄 其他变更

## 🛠️ 测试验证说明

**1. 对于纯软件逻辑**：
- [x] 已在本地通过 XMake 编译（host 平台）。
- 该改动为纯重命名（`AW_MO_*` → `MO_*`），不改变任何运行时行为，编译通过即可验证正确性。

## ⚠️ 影响范围分析
- 是否修改了现有的对外 API 接口？👉 是 *(宏名称变更：`AW_MO_RELAXED` → `MO_RELAXED` 等，所有使用 `AW_MO_*` 的外部代码需同步更新)*
- 是否修改了现有的对外数据结构？👉 否

## 🔗 Issue 关联与关闭策略
- 目标为 `integration`，本 PR 填写：暂无关联 Issue

## ✅ 提交者自查清单
- [x] 代码风格符合团队统一规范，变量/函数命名语义清晰。
- [x] 核心复杂逻辑已添加了充分的中文注释。
- [x] 本地分支已经基于最新的 `integration` 分支同步过代码，确保当前无冲突。
- [x] 本次提交序列已按单一职责拆分。
- [x] 未夹带无关注释、空行或排版改动。
- [x] 提交信息符合 `类型(作用域): 简短描述`。