### PR TITLE
feat(build): DAPLink (OpenOCD) 烧录/调试支持 + armclang ELF LOAD segment 修复

### DIFF
--- a/build/config/options.lua
+++ b/build/config/options.lua
@@ -147,10 +147,6 @@ local function persist_flash_preset(config, preset)
     if type(flash) ~= "table" then
         return
     end
-    local jlink = type(flash.jlink) == "table" and flash.jlink or flash
-    if type(jlink) ~= "table" then
-        return
-    end
     local has_value = false
     --- 写入单个字段
     ---@param key string 字段名
@@ -163,16 +159,28 @@ local function persist_flash_preset(config, preset)
         config.set("om_flash_" .. key, value)
         has_value = true
     end
-    set_flash_value("device", jlink.device)
-    set_flash_value("interface", jlink.interface)
-    set_flash_value("speed", jlink.speed)
-    set_flash_value("program", jlink.program)
-    set_flash_value("target", jlink.target)
-    set_flash_value("firmware", jlink.firmware)
-    set_flash_value("file", jlink.file)
-    set_flash_value("prefer_hex", jlink.prefer_hex)
-    set_flash_value("reset", jlink.reset)
-    set_flash_value("run", jlink.run)
+    -- 通用字段
+    set_flash_value("flasher", flash.flasher)
+    set_flash_value("target", flash.target)
+    set_flash_value("firmware", flash.firmware)
+    set_flash_value("file", flash.file)
+    set_flash_value("prefer_hex", flash.prefer_hex)
+    set_flash_value("reset", flash.reset)
+    set_flash_value("run", flash.run)
+    set_flash_value("native_output", flash.native_output)
+    -- jlink 子表
+    if type(flash.jlink) == "table" then
+        set_flash_value("jlink_device", flash.jlink.device)
+        set_flash_value("jlink_interface", flash.jlink.interface)
+        set_flash_value("jlink_speed", flash.jlink.speed)
+        set_flash_value("jlink_program", flash.jlink.program)
+    end
+    -- daplink 子表
+    if type(flash.daplink) == "table" then
+        set_flash_value("daplink_config", flash.daplink.config)
+        set_flash_value("daplink_frequency", flash.daplink.frequency)
+        set_flash_value("daplink_program", flash.daplink.program)
+    end
     if has_value then
         config.save()
     end

--- a/build/rules/image_convert.lua
+++ b/build/rules/image_convert.lua
@@ -17,16 +17,74 @@ rule("oh_my_robot.image_convert")
         local toolchain_lib = import("toolchain_lib", {rootdir = modules_root})
         local toolchain_config = toolchain_lib.get_toolchain_config()
         local converters = toolchain_lib.resolve_image_converters(toolchain_config, context.toolchain_name)
-        if not converters then
-            return
+        if converters then
+            local elf_file = target:targetfile()
+            local output_dir = target:targetdir()
+            local basename = target:basename()
+            local hex_file = path.join(output_dir, basename .. ".hex")
+            local bin_file = path.join(output_dir, basename .. ".bin")
+            toolchain_lib.run_image_convert(converters.hex, elf_file, hex_file)
+            toolchain_lib.run_image_convert(converters.bin, elf_file, bin_file)
         end
-        local elf_file = target:targetfile()
-        local output_dir = target:targetdir()
-        local basename = target:basename()
-        local hex_file = path.join(output_dir, basename .. ".hex")
-        local bin_file = path.join(output_dir, basename .. ".bin")
-        toolchain_lib.run_image_convert(converters.hex, elf_file, hex_file)
-        toolchain_lib.run_image_convert(converters.bin, elf_file, bin_file)
+        -- armlink produces ELF with single LOAD segment that does not encode
+        -- VMA/LMA separation for RW data. Add a second LOAD segment so GDB
+        -- loads .data init values to flash LMA rather than RAM VMA.
+        if context.toolchain_name == "armclang" then
+            local elf_file = target:targetfile()
+            if os.isfile(elf_file) then
+                local f = io.open(elf_file, "rb")
+                if f then
+                    local data = f:read("a")
+                    f:close()
+                    if data:sub(1, 4) == "\127ELF" and data:byte(5) == 1 and data:byte(6) == 1 then
+                        -- ELF32 header (1-based positions): e_phoff@0x1D  e_shoff@0x21
+                        local e_phoff, e_shoff = string.unpack("<I4I4", data, 0x1D)
+                        -- e_phnum@0x2D  e_shentsize@0x2F  e_shnum@0x31  e_shstrndx@0x33
+                        local e_phnum, e_shentsize = string.unpack("<HH", data, 0x2D)
+                        local e_shnum, e_shstrndx = string.unpack("<HH", data, 0x31)
+                        if e_shstrndx ~= 0 and e_shstrndx < e_shnum then
+                            -- String table section header: sh_offset@0x10  sh_size@0x14
+                            local strtab_hdr = 1 + e_shoff + e_shstrndx * e_shentsize
+                            local strtab_off = string.unpack("<I4", data, strtab_hdr + 0x10)
+                            -- Find RW_IRAM1 PROGBITS section
+                            local rw_off, rw_sz
+                            for i = 0, e_shnum - 1 do
+                                local sh = 1 + e_shoff + i * e_shentsize
+                                local sh_name, sh_type = string.unpack("<I4I4", data, sh)
+                                local sh_addr, sh_offset, sh_size = string.unpack("<I4I4I4", data, sh + 0xC)
+                                if sh_type == 1 and sh_addr == 0x20000000 then  -- SHT_PROGBITS
+                                    local ns = 1 + strtab_off + sh_name
+                                    local ne = data:find("\0", ns)
+                                    local name = data:sub(ns, (ne or (ns + 255)) - 1)
+                                    if name:find("RW") then
+                                        rw_off, rw_sz = sh_offset, sh_size
+                                        break
+                                    end
+                                end
+                            end
+                            if rw_off and rw_sz > 0 then
+                                local flash_lma = 0x08000000 + (rw_off - 0x40)
+                                -- ELF32_Phdr: p_type p_offset p_vaddr p_paddr p_filesz p_memsz p_flags p_align
+                                local new_phdr = string.pack("<I4I4I4I4I4I4I4I4",
+                                    1, rw_off, 0x20000000, flash_lma,
+                                    rw_sz, rw_sz, 2 | 4, 8)
+                                local ins_pos = 1 + e_phoff + e_phnum * 0x20
+                                data = data:sub(1, ins_pos - 1) .. new_phdr .. data:sub(ins_pos)
+                                -- Update e_phnum (+1)
+                                data = data:sub(1, 0x2C) .. string.pack("<H", e_phnum + 1) .. data:sub(0x2F)
+                                -- Update e_shoff (+0x20)
+                                data = data:sub(1, 0x20) .. string.pack("<I4", e_shoff + 0x20) .. data:sub(0x25)
+                                f = io.open(elf_file, "wb")
+                                if f then
+                                    f:write(data)
+                                    f:close()
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
     end)
     --- 清理时删除生成的 hex/bin 镜像
     ---@param target target 目标对象

--- a/build/tasks/flash.lua
+++ b/build/tasks/flash.lua
@@ -1,32 +1,32 @@
 --- @task flash
---- @brief J-Link 烧录任务
---- @details 通过 J-Link Commander 对目标进行烧录。
+--- @brief 统一烧录任务
+--- @details 通过策略模式支持 J-Link / DAPLink 等多种调试器。
 task("flash")
     set_menu {
         usage = "xmake flash [options]",
-        description = "Flash firmware via J-Link",
+        description = "Flash firmware via J-Link / DAPLink",
         options = {
-            {"d", "device", "kv", nil, "J-Link device name"},
-            {"i", "interface", "kv", nil, "J-Link interface"},
-            {"s", "speed", "kv", nil, "J-Link speed (kHz)"},
-            {"f", "firmware", "kv", nil, "Firmware file (.hex/.elf)"},
-            {"H", "prefer_hex", "kv", nil, "Prefer HEX when auto resolving firmware (true/false)"},
-            {"p", "program", "kv", nil, "J-Link executable path"},
-            {"t", "target", "kv", nil, "Target name"},
-            {"r", "reset", "kv", "true", "Reset before/after flash"},
+            {nil, "flasher", "kv", nil, "Flasher type: jlink, daplink"},
+            {"d", "device", "kv", nil, "J-Link device name / pyOCD target name"},
+            {"i", "interface", "kv", nil, "J-Link interface (swd/jtag)"},
+            {"s", "speed", "kv", nil, "J-Link speed (kHz) / DAPLink frequency (Hz)"},
+            {"f", "firmware", "kv", nil, "Firmware file (.hex/.elf/.bin)"},
+            {"H", "prefer_hex", "kv", nil, "Prefer HEX when auto resolving (true/false)"},
+            {"p", "program", "kv", nil, "Flasher executable path"},
+            {"t", "target", "kv", nil, "Target name (xmake target)"},
+            {"r", "reset", "kv", "true", "Reset after flash"},
             {"g", "run", "kv", "true", "Run after flash"},
-            {"n", "native_output", "kv", nil, "Show native flasher CLI output (true/false)"},
+            {"n", "native_output", "kv", nil, "Show native flasher CLI output"},
+            {"u", "uid", "kv", nil, "DAPLink probe serial number / UID"},
         }
     }
     on_run(function()
-        -- 脚本域内定义流水线与工具函数，避免描述域使用脚本接口
+        -- ===================================================================
+        -- 工具函数
+        -- ===================================================================
         local build_root = path.join(os.scriptdir(), "..")
         local modules_root = path.join(build_root, "modules")
 
-        --- 解析布尔值
-        ---@param value string|boolean|nil 输入值
-        ---@param default_value boolean 默认值
-        ---@return boolean result
         local function resolve_bool(value, default_value)
             if value == nil then
                 return default_value
@@ -44,9 +44,6 @@ task("flash")
             return default_value
         end
 
-        --- 获取绝对路径
-        ---@param file_path string 文件路径
-        ---@return string absolute_path
         local function resolve_path(file_path)
             if path.is_absolute(file_path) then
                 return file_path
@@ -54,7 +51,6 @@ task("flash")
             return path.join(os.projectdir(), file_path)
         end
 
-        -- normalize extension (lowercase, with leading dot)
         local function normalize_extension(file_path)
             local ext = path.extension(file_path) or ""
             ext = ext:lower()
@@ -64,7 +60,6 @@ task("flash")
             return ext
         end
 
-        -- ensure firmware path has explicit extension
         local function ensure_firmware_extension(file_path)
             local ext = normalize_extension(file_path)
             if ext == ".elf" or ext == ".hex" or ext == ".bin" then
@@ -73,7 +68,6 @@ task("flash")
             raise("firmware must include explicit extension: .elf/.hex/.bin")
         end
 
-        -- read config scalar value
         local function read_config_scalar(value)
             if type(value) == "table" then
                 return value[1]
@@ -81,7 +75,6 @@ task("flash")
             return value
         end
 
-        -- normalize toolchain name (strip bracket suffix)
         local function normalize_toolchain_name(name)
             if not name or name == "" then
                 return name
@@ -90,25 +83,28 @@ task("flash")
             return base or name
         end
 
-        --- 读取预设中的 J-Link 配置
-        ---@return table|nil preset
-        local function load_jlink_preset()
+        --- 从 flash preset 提取通用字段（兼容新旧格式）
+        local function read_common_value(flash_preset, key)
+            if not flash_preset then
+                return nil
+            end
+            if flash_preset[key] ~= nil and flash_preset[key] ~= "" then
+                return flash_preset[key]
+            end
+            return nil
+        end
+
+        --- 加载 flash 预设
+        local function load_flash_preset()
             local oh_my_robot = import("oh-my-robot", {rootdir = modules_root})
             local preset = oh_my_robot.get_preset()
             if not preset or type(preset) ~= "table" then
                 return nil
             end
-            local flash_preset = preset.flash
-            if type(flash_preset) ~= "table" then
-                return nil
-            end
-            if type(flash_preset.jlink) == "table" then
-                return flash_preset.jlink
-            end
-            return flash_preset
+            return preset.flash
         end
 
-        -- load toolchain preset name
+        --- 加载工具链预设名
         local function load_toolchain_preset()
             local oh_my_robot = import("oh-my-robot", {rootdir = modules_root})
             local preset = oh_my_robot.get_preset()
@@ -116,25 +112,7 @@ task("flash")
             return toolchain_default and toolchain_default.name or nil
         end
 
-        --- 读取预设字段
-        ---@param preset table|nil 预设表
-        ---@param key string 字段名
-        ---@return any value
-        local function read_preset_value(preset, key)
-            if not preset then
-                return nil
-            end
-            local value = preset[key]
-            if value == nil or value == "" then
-                return nil
-            end
-            return value
-        end
-
         --- 解析目标输出文件
-        ---@param target_name string 目标名称
-        ---@param prefer_hex boolean 是否优先使用 HEX
-        ---@return string file_path
         local function resolve_target_output(target_name, prefer_hex)
             local project = import("core.project.project")
             project.load_targets()
@@ -169,80 +147,242 @@ task("flash")
             raise("flash file not found: please build target and enable oh_my_robot.image_convert")
         end
 
-        --- 解析 J-Link 可执行程序
-        ---@param program string|nil 用户指定路径
-        ---@return string program_path
-        local function resolve_jlink_program(program)
-            if program and program ~= "" then
-                local abs = resolve_path(program)
-                if os.isexec(abs) then
-                    return abs
-                end
-                raise("jlink program not executable: " .. abs)
-            end
+        --- 通用程序查找
+        local function find_program(name, paths)
             local find_tool = import("lib.detect.find_tool")
-            local tool = find_tool("JLink", {paths = {}})
+            local tool = find_tool(name, {paths = paths or {}})
             if tool and tool.program and os.isexec(tool.program) then
                 return tool.program
             end
-            tool = find_tool("JLink.exe", {paths = {}})
-            if tool and tool.program and os.isexec(tool.program) then
-                return tool.program
-            end
-            raise("J-Link program not found: please pass --program=<path>")
+            return nil
         end
 
-        --- 生成 J-Link 命令文件内容
-        ---@param device string 设备名
-        ---@param interface string 接口类型
-        ---@param speed string|number 速度
-        ---@param firmware string 烧录文件
-        ---@param firmware_size number|nil 固件文件大小（bytes），bin 烧录时需要
-        ---@param reset_after boolean 是否重置
-        ---@param run_after boolean 是否运行
-        ---@return string content
-        local function build_jlink_command(device, interface, speed, firmware, firmware_size, reset_after, run_after)
-            local lines = {}
-            lines[#lines + 1] = "device " .. device
-            lines[#lines + 1] = "if " .. interface
-            lines[#lines + 1] = "speed " .. tostring(speed)
-            if reset_after then
-                lines[#lines + 1] = "r"
+        -- ===================================================================
+        -- Flasher 策略：J-Link
+        -- ===================================================================
+        local flasher_jlink = {
+            name = "jlink",
+
+            resolve_config = function(self, ctx)
+                local option = ctx.option
+                local preset = ctx.flash_preset
+
+                local jlink_preset = nil
+                if preset then
+                    if type(preset.jlink) == "table" then
+                        jlink_preset = preset.jlink
+                    elseif not preset.flasher then
+                        -- 旧格式：整个 flash 表就是 jlink 配置
+                        jlink_preset = preset
+                    end
+                end
+
+                local config = {
+                    device = option.get("device")
+                        or (jlink_preset and jlink_preset.device)
+                        or "STM32F407IG",
+                    interface = option.get("interface")
+                        or (jlink_preset and jlink_preset.interface)
+                        or "swd",
+                    speed = option.get("speed")
+                        or (jlink_preset and jlink_preset.speed)
+                        or "4000",
+                    program = option.get("program")
+                        or (jlink_preset and jlink_preset.program),
+                    reset_after = resolve_bool(
+                        option.get("reset") or read_common_value(preset, "reset"),
+                        true
+                    ),
+                    run_after = resolve_bool(
+                        option.get("run") or read_common_value(preset, "run"),
+                        true
+                    ),
+                    native_output = resolve_bool(
+                        option.get("native_output") or read_common_value(preset, "native_output"),
+                        false
+                    ),
+                }
+                ctx.flasher_config = config
+                return ctx
+            end,
+
+            get_program = function(config)
+                if config.program and config.program ~= "" then
+                    local abs = resolve_path(config.program)
+                    if os.isexec(abs) then
+                        return abs
+                    end
+                    raise("jlink program not executable: " .. abs)
+                end
+                local found = find_program("JLink")
+                    or find_program("JLink.exe")
+                if found then
+                    return found
+                end
+                raise("J-Link program not found: please pass --program=<path>")
+            end,
+
+            build_command = function(config, firmware, build_dir)
+                local firmware_size = nil
+                if normalize_extension(firmware) == ".bin" then
+                    firmware_size = os.filesize(firmware)
+                    if not firmware_size or firmware_size == 0 then
+                        raise("cannot determine firmware file size: " .. firmware)
+                    end
+                end
+
+                local lines = {}
+                lines[#lines + 1] = "device " .. config.device
+                lines[#lines + 1] = "if " .. config.interface
+                lines[#lines + 1] = "speed " .. tostring(config.speed)
+                if config.reset_after then
+                    lines[#lines + 1] = "r"
+                end
+                lines[#lines + 1] = "halt"
+                local ext = normalize_extension(firmware)
+                if ext == ".bin" then
+                    local end_addr = 0x08000000 + firmware_size
+                    lines[#lines + 1] = string.format("erase 0x08000000, 0x%08X", end_addr)
+                    lines[#lines + 1] = "loadbin " .. firmware .. ", 0x08000000"
+                    lines[#lines + 1] = "verifybin " .. firmware .. ", 0x08000000"
+                else
+                    lines[#lines + 1] = "loadfile " .. firmware
+                end
+                if config.reset_after then
+                    lines[#lines + 1] = "r"
+                end
+                if config.run_after then
+                    lines[#lines + 1] = "g"
+                end
+                lines[#lines + 1] = "q"
+
+                local flash_dir = path.join(build_dir, "oh-my-robot", "flash")
+                os.mkdir(flash_dir)
+                local command_path = path.join(flash_dir, "jlink_flash.jlink")
+                io.writefile(command_path, table.concat(lines, "\n") .. "\n")
+                return {"-CommandFile", command_path}
+            end,
+        }
+
+        -- ===================================================================
+        -- Flasher 策略：DAPLink (OpenOCD)
+        -- ===================================================================
+        local flasher_daplink = {
+            name = "daplink",
+
+            resolve_config = function(self, ctx)
+                local option = ctx.option
+                local preset = ctx.flash_preset
+
+                local daplink_preset = nil
+                if preset and type(preset.daplink) == "table" then
+                    daplink_preset = preset.daplink
+                end
+
+                local config = {
+                    config_file = (daplink_preset and daplink_preset.config),
+                    frequency = option.get("speed")
+                        or (daplink_preset and daplink_preset.frequency)
+                        or 4000,
+                    program = option.get("program")
+                        or (daplink_preset and daplink_preset.program),
+                    reset_after = resolve_bool(
+                        option.get("reset") or read_common_value(preset, "reset"),
+                        true
+                    ),
+                    run_after = resolve_bool(
+                        option.get("run") or read_common_value(preset, "run"),
+                        true
+                    ),
+                    native_output = resolve_bool(
+                        option.get("native_output") or read_common_value(preset, "native_output"),
+                        false
+                    ),
+                }
+                ctx.flasher_config = config
+                return ctx
+            end,
+
+            get_program = function(config)
+                if config.program and config.program ~= "" then
+                    local abs = resolve_path(config.program)
+                    if os.isexec(abs) then
+                        return abs
+                    end
+                    local found = find_program(config.program)
+                    if found then
+                        return found
+                    end
+                    raise("openocd program not found: " .. abs)
+                end
+                local found = find_program("openocd")
+                if found then
+                    return found
+                end
+                raise("openocd not found: please install OpenOCD or pass --program=<path>")
+            end,
+
+            build_command = function(config, firmware, build_dir)
+                local args = {}
+                if config.config_file then
+                    args[#args + 1] = "-f"
+                    args[#args + 1] = resolve_path(config.config_file)
+                end
+                if config.frequency then
+                    args[#args + 1] = "-c"
+                    args[#args + 1] = "adapter speed " .. tostring(config.frequency)
+                end
+                -- 将反斜杠转为正斜杠，避免 OpenOCD TCL 将其当作转义符
+                local normalized_fw = firmware:gsub("\\", "/")
+                local flash_cmd = "program " .. normalized_fw .. " verify"
+                if config.reset_after then
+                    flash_cmd = flash_cmd .. " reset"
+                end
+                flash_cmd = flash_cmd .. " exit"
+                args[#args + 1] = "-c"
+                args[#args + 1] = flash_cmd
+                return args
+            end,
+        }
+
+        -- ===================================================================
+        -- Flasher 注册表
+        -- ===================================================================
+        local flasher_registry = {}
+
+        local function register_flasher(flasher)
+            if not flasher or not flasher.name then
+                raise("flasher register: name required")
             end
-            lines[#lines + 1] = "halt"
-            local ext = normalize_extension(firmware)
-            if ext == ".bin" then
-                local end_addr = 0x08000000 + firmware_size
-                lines[#lines + 1] = string.format("erase 0x08000000, 0x%08X", end_addr)
-                lines[#lines + 1] = "loadbin " .. firmware .. ", 0x08000000"
-                lines[#lines + 1] = "verifybin " .. firmware .. ", 0x08000000"
-            else
-                lines[#lines + 1] = "loadfile " .. firmware
+            if flasher_registry[flasher.name] then
+                raise("flasher register: duplicate name " .. flasher.name)
             end
-            if reset_after then
-                lines[#lines + 1] = "r"
-            end
-            if run_after then
-                lines[#lines + 1] = "g"
-            end
-            lines[#lines + 1] = "q"
-            return table.concat(lines, "\n") .. "\n"
+            flasher_registry[flasher.name] = flasher
         end
 
-        --- 写入 J-Link 命令文件
-        ---@param build_dir string 构建目录
-        ---@param content string 命令内容
-        ---@return string command_path
-        local function write_jlink_command_file(build_dir, content)
-            local flash_dir = path.join(build_dir, "oh-my-robot", "flash")
-            os.mkdir(flash_dir)
-            local command_path = path.join(flash_dir, "jlink_flash.jlink")
-            io.writefile(command_path, content)
-            return command_path
+        local function get_flasher(name)
+            return flasher_registry[name]
         end
 
-        --- 构建上下文
-        ---@return table context
+        local function detect_flasher_from_preset(preset)
+            if not preset then
+                return "jlink"
+            end
+            if preset.flasher then
+                return preset.flasher
+            end
+            -- 旧格式兼容：无 flasher 字段默认为 jlink
+            return "jlink"
+        end
+
+        register_flasher(flasher_jlink)
+        register_flasher(flasher_daplink)
+
+        -- ===================================================================
+        -- 流水线步骤
+        -- ===================================================================
+
+        --- Step 0: 构建上下文
         local function build_context()
             local config = import("core.project.config")
             local option = import("core.base.option")
@@ -261,26 +401,42 @@ task("flash")
             return {
                 config = config,
                 option = option,
-                preset = load_jlink_preset(),
+                flash_preset = load_flash_preset(),
             }
         end
 
-        --- Step: 解析固件路径与选择策略
-        ---@param ctx table 上下文
-        ---@return table ctx
+        --- Step 1: 加载 flasher 策略
+        local function step_load_flasher(ctx)
+            local flasher_name = ctx.option.get("flasher")
+            if not flasher_name then
+                flasher_name = detect_flasher_from_preset(ctx.flash_preset)
+            end
+            ctx.flasher = get_flasher(flasher_name)
+            if not ctx.flasher then
+                local names = {}
+                for k, _ in pairs(flasher_registry) do
+                    names[#names + 1] = k
+                end
+                raise("unknown flasher: " .. flasher_name
+                    .. ". Available: " .. table.concat(names, ", "))
+            end
+            return ctx
+        end
+
+        --- Step 2: 解析固件路径
         local function step_resolve_firmware(ctx)
             local option = ctx.option
-            local preset = ctx.preset
+            local preset = ctx.flash_preset
             ctx.target_name = option.get("target")
-                or read_preset_value(preset, "target")
+                or read_common_value(preset, "target")
                 or "robot_project"
             ctx.prefer_hex = resolve_bool(
-                option.get("prefer_hex") or read_preset_value(preset, "prefer_hex"),
+                option.get("prefer_hex") or read_common_value(preset, "prefer_hex"),
                 true
             )
             local file_override = option.get("firmware")
-                or read_preset_value(preset, "firmware")
-                or read_preset_value(preset, "file")
+                or read_common_value(preset, "firmware")
+                or read_common_value(preset, "file")
             if file_override then
                 ensure_firmware_extension(file_override)
             end
@@ -292,86 +448,44 @@ task("flash")
             return ctx
         end
 
-        --- Step: 解析设备、接口与执行器
-        ---@param ctx table 上下文
-        ---@return table ctx
-        local function step_resolve_driver(ctx)
-            local option = ctx.option
-            local preset = ctx.preset
-            ctx.device = option.get("device")
-                or read_preset_value(preset, "device")
-                or "STM32F407IG"
-            ctx.interface = option.get("interface")
-                or read_preset_value(preset, "interface")
-                or "swd"
-            ctx.speed = option.get("speed")
-                or read_preset_value(preset, "speed")
-                or "4000"
-            ctx.reset_after = resolve_bool(
-                option.get("reset") or read_preset_value(preset, "reset"),
-                true
-            )
-            ctx.run_after = resolve_bool(
-                option.get("run") or read_preset_value(preset, "run"),
-                true
-            )
-            ctx.native_output = resolve_bool(
-                option.get("native_output") or read_preset_value(preset, "native_output"),
-                false
-            )
-            ctx.program = resolve_jlink_program(
-                option.get("program") or read_preset_value(preset, "program")
-            )
+        --- Step 3: 解析 flasher 配置
+        local function step_resolve_flasher_config(ctx)
+            ctx.flasher:resolve_config(ctx)
             return ctx
         end
 
-        --- Step: 生成命令并写入临时文件
-        ---@param ctx table 上下文
-        ---@return table ctx
+        --- Step 4: 准备命令
         local function step_prepare_command(ctx)
-            local firmware_size = nil
-            if normalize_extension(ctx.firmware) == ".bin" then
-                firmware_size = os.filesize(ctx.firmware)
-                if not firmware_size or firmware_size == 0 then
-                    raise("cannot determine firmware file size: " .. ctx.firmware)
-                end
-            end
-            local command_content = build_jlink_command(
-                ctx.device,
-                ctx.interface,
-                ctx.speed,
+            ctx.program = ctx.flasher.get_program(ctx.flasher_config)
+            ctx.args = ctx.flasher.build_command(
+                ctx.flasher_config,
                 ctx.firmware,
-                firmware_size,
-                ctx.reset_after,
-                ctx.run_after
+                ctx.config.builddir()
             )
-            ctx.command_path = write_jlink_command_file(ctx.config.builddir(), command_content)
             return ctx
         end
 
-        --- Step: 执行烧录
-        ---@param ctx table 上下文
-        ---@return table ctx
+        --- Step 5: 执行烧录
         local function step_execute(ctx)
-            local command_arguments = {"-CommandFile", ctx.command_path}
-            if ctx.native_output then
-                os.execv(ctx.program, command_arguments)
+            if ctx.flasher_config.native_output then
+                os.execv(ctx.program, ctx.args)
             else
-                os.runv(ctx.program, command_arguments)
+                os.runv(ctx.program, ctx.args)
             end
-            -- 输出实际使用的可执行文件路径与工具链信息
             local toolchain_name = ctx.config and ctx.config.get("toolchain") or "unknown"
+            print("[oh-my-robot] flash flasher: " .. ctx.flasher.name)
             print("[oh-my-robot] flash program: " .. tostring(ctx.program))
             print("[oh-my-robot] flash firmware: " .. tostring(ctx.firmware))
             print("[oh-my-robot] flash toolchain: " .. tostring(toolchain_name))
-            print("[oh-my-robot] flash native output: " .. tostring(ctx.native_output))
+            print("[oh-my-robot] flash native output: " .. tostring(ctx.flasher_config.native_output))
             return ctx
         end
 
         local ctx = build_context()
         local steps = {
+            step_load_flasher,
             step_resolve_firmware,
-            step_resolve_driver,
+            step_resolve_flasher_config,
             step_prepare_command,
             step_execute,
         }

--- a/docs/build/build_tasks_manual.md
+++ b/docs/build/build_tasks_manual.md
@@ -3,7 +3,7 @@
 ## 1. 目标与范围
 本手册用于说明 OM 内置任务的职责、参数与使用方式。当前包含：
 - `xmake init_workspace`：为当前 `oh-my-robot` checkout 生成轻量项目壳。
-- `xmake flash`：通过 J-Link Commander 烧录目标固件。
+- `xmake flash`：通过策略模式支持 J-Link / DAPLink (OpenOCD) 等多种调试器烧录。
 
 ## 2. 参数优先级
 任务参数的优先级统一为：
@@ -50,42 +50,61 @@ xmake init_workspace --output="../workspaces/oh-my-robot/16-build-env"
 3) 若目标 `om_preset.lua` 已存在，只有在 `--force=true` 时才会覆盖。
 
 ### 3.2 `xmake flash`
-**职责**：使用 J-Link Commander 对目标固件进行烧录。
+**职责**：通过策略模式支持 J-Link / DAPLink (OpenOCD) 等多种调试器对目标固件进行烧录。
 
 **前置条件**：
 - 工程已构建，且目标产物存在（默认使用 `target:targetfile()` 或生成的 `.hex`）。
-- 已安装 J-Link 软件包，并配置可执行路径。
+- J-Link 链路：已安装 J-Link 软件包。
+- DAPLink 链路：已安装 OpenOCD（建议 `0.12.0` 及以上）。
 
 **命令示例**：
 ```sh
-xmake flash --device=STM32F407IG --interface=swd --speed=4000 --program="D:/Program Files/ProgramTools/SEGGER/Jlink/JLink.exe"
+# J-Link 烧录（默认）
+xmake flash --device=STM32F427II --interface=swd --speed=4000
+
+# DAPLink 烧录
+xmake flash --flasher=daplink
+
+# 指定 OpenOCD 程序路径
+xmake flash --flasher=daplink --program="D:/openocd-win/bin/openocd.exe"
 ```
 
-**参数说明**：
+**通用参数说明**（所有烧录器适用）：
+| 参数 | 说明 | 默认值 | 预设字段 | 备注 |
+| --- | --- | --- | --- | --- |
+| `--flasher` | 烧录器类型 | preset 或 `jlink` | `flash.flasher` | 可选：`jlink` / `daplink` |
+| `--target` | XMake 目标名称 | `robot_project` | `flash.target` | 用于自动推导产物路径 |
+| `--firmware` | 固件文件路径（覆盖自动推导） | 无 | `flash.firmware` | 必须显式包含 `.hex` / `.elf` / `.bin` |
+| `--prefer_hex` | 自动推导时优先使用 HEX | `true` | `flash.prefer_hex` | 仅在未指定 `--firmware` 时生效 |
+| `--reset` | 烧录前后是否复位 | `true` | `flash.reset` | `true`/`false` |
+| `--run` | 烧录完成后是否运行 | `true` | `flash.run` | `true`/`false` |
+| `--native_output` | 是否透传烧录器原生输出 | `false` | `flash.native_output` | `true`/`false` |
+
+**J-Link 专有参数**：
 | 参数 | 说明 | 默认值 | 预设字段 | 备注 |
 | --- | --- | --- | --- | --- |
 | `--device` | 目标芯片名称（J-Link 设备名） | `STM32F407IG` | `flash.jlink.device` | 必须为 J-Link 支持的设备名 |
 | `--interface` | 调试接口类型 | `swd` | `flash.jlink.interface` | 可选：`swd` / `jtag` |
-| `--speed` | 接口速度（kHz） | `4000` | `flash.jlink.speed` | 可使用 `auto`（若 J-Link 支持） |
-| `--program` | J-Link Commander 可执行文件路径 | 无 | `flash.jlink.program` | 必填，否则自动查找失败时会报错 |
-| `--target` | XMake 目标名称 | `robot_project` | `flash.jlink.target` | 用于自动推导产物路径 |
-| `--firmware` | 固件文件路径（覆盖自动推导） | 无 | `flash.jlink.firmware` | 必须显式包含 `.hex` / `.elf` / `.bin` |
-| `--prefer_hex` | 自动推导时优先使用 HEX | `true` | `flash.jlink.prefer_hex` | 仅在未指定 `--firmware` 时生效 |
-| `--reset` | 烧录前后是否复位 | `true` | `flash.jlink.reset` | `true`/`false` |
-| `--run` | 烧录完成后是否运行 | `true` | `flash.jlink.run` | `true`/`false` |
-| `--native_output` | 是否透传烧录器原生输出 | `false` | `flash.jlink.native_output` | `true`/`false` |
+| `--speed` | 接口速度（kHz） | `4000` | `flash.jlink.speed` | J-Link 链路的速度单位 |
+| `--program` | JLink.exe 可执行文件路径 | 无 | `flash.jlink.program` | 未配置时自动查找 PATH |
+
+**DAPLink (OpenOCD) 专有参数**：
+| 参数 | 说明 | 默认值 | 预设字段 | 备注 |
+| --- | --- | --- | --- | --- |
+| `--speed` | 适配器频率（Hz） | `4000` | `flash.daplink.frequency` | DAPLink 链路的频率单位 |
+| `--program` | openocd.exe 可执行文件路径 | 无 | `flash.daplink.program` | 未配置时自动查找 PATH |
 
 **产物选择策略**：
-1) 若指定 `--firmware` 或 `flash.jlink.firmware`（或兼容字段 `flash.jlink.file`），直接使用该文件（必须带后缀）。
-2) 否则根据 `--target`/`flash.jlink.target` 推导产物。
+1) 若指定 `--firmware` 或 `flash.firmware`（或兼容字段 `flash.file`），直接使用该文件（必须带后缀）。
+2) 否则根据 `--target`/`flash.target` 推导产物。
 3) 当 `prefer_hex=true` 时，若存在 `.hex` 优先使用；否则回退到 `.elf`。
 
 **输出与行为**：
-- 任务会在 `build/<profile>/oh-my-robot/flash/` 下生成临时的 J-Link 命令文件。
-- 烧录结束后 J-Link 自动退出。
+- J-Link 链路：任务会在 `build/<profile>/oh-my-robot/flash/` 下生成临时的 J-Link 命令文件，烧录结束后 J-Link 自动退出。
+- DAPLink 链路：通过 OpenOCD `program` 命令完成烧录与校验，支持 `verify reset exit` 流程。
 - 若预设中的 toolchain 与配置不一致，会在烧录前输出警告并以配置为准。
-- 成功执行后会输出实际使用的可执行文件路径、固件路径与 toolchain。
-- 当 `native_output=true` 时，终端会透传 J-Link Commander 的原生输出。
+- 成功执行后会输出实际使用的 flasher 类型、可执行文件路径、固件路径与 toolchain。
+- 当 `native_output=true` 时，终端会透传烧录器原生输出（J-Link Commander 或 OpenOCD）。
 - 当前已知限制：使用 `--firmware` 指向 `.elf` 时可能无法实际烧录，请优先使用 `.hex`。
 
 ## 4. `om_preset.lua` 预设示例
@@ -93,17 +112,23 @@ xmake flash --device=STM32F407IG --interface=swd --speed=4000 --program="D:/Prog
 
 ```lua
 flash = {
+  flasher = "jlink",           -- 默认烧录器：jlink / daplink
+  target = "robot_project",
+  firmware = nil,
+  prefer_hex = true,
+  reset = true,
+  run = true,
+  native_output = false,
   jlink = {
     device = "STM32F407IG",
     interface = "swd",
     speed = 4000,
     program = "D:/Program Files/ProgramTools/SEGGER/Jlink/JLink.exe",
-    target = "robot_project",
-    firmware = nil,
-    prefer_hex = true,
-    reset = true,
-    run = true,
-    native_output = false,
+  },
+  daplink = {
+    program = "D:/openocd-win/bin/openocd.exe",
+    config = ".vscode/daplink.cfg",
+    frequency = 4000,
   },
 }
 ```

--- a/docs/build/maintenance_manual.md
+++ b/docs/build/maintenance_manual.md
@@ -45,7 +45,8 @@
 自定义任务：
 - `xmake init_workspace`：为当前 `oh-my-robot` checkout 生成轻量项目壳，并创建本地 `oh-my-robot` 目录链接/junction，解决单独 worktree 缺少顶层 `xmake.lua` 的问题。
 - `xmake flash`：通过 J-Link Commander 烧录，默认优先使用 HEX，可通过 `--firmware` 指定 ELF/HEX，并可通过 `--native_output=true` 透传原生输出。
-- 调试器支持矩阵（当前）：`om_preset.flash` 仅接入 `jlink`；`daplink` 尚未实现，仅作为规划项记录。
+- `xmake flash`：通过策略模式支持 J-Link (JLink.exe) 与 DAPLink (OpenOCD) 两种烧录器，通过 `--flasher` 或 `flash.flasher` 切换。J-Link 链路生成 `.jlink` 命令文件调用 JLink.exe；DAPLink 链路通过 OpenOCD `program` 命令完成烧录与校验。
+- 调试器支持矩阵（当前）：`om_preset.flash` 同时支持 `jlink` 与 `daplink`，通过策略模式注册表统一管理。
 
 
 ## 5. 目录职责与依赖方向简图
@@ -399,11 +400,12 @@ end
 - 出现 `attempt to concatenate a nil value (global 'sourcefile')`：请检查本机 XMake 是否低于 `3.0.7`，并升级后重试。
 - Cortex-Debug `armclang + load` 初始化异常：优先切换为 `restore <profile>.hex` 下载链路。
 - weak 覆盖未生效：检查 `override_sources` 是否登记、是否被 `oh_my_robot.board_assets` 注入到 `binary`，并核对最终 ELF 符号是否仍为 `W/weak`。
-- 预设中配置了 `flash.daplink` 但不生效：当前任务链路只读取 `flash.jlink`，DAPLink 尚未接入实现。
+- 预设中配置了 `flash.daplink` 但 OpenOCD 找不到：检查 `flash.daplink.program` 路径是否正确，或确认 OpenOCD 已加入 PATH。
 - `[oh-my-robot] link contract check failed`：`tar_os`/`tar_sync` 的关键符号未以强符号形态提供；应回查模块构建输入与依赖传播，不要在应用目标补直连依赖。
 
 ## 13. 变更记录
-- 2026-03-26：preset 解析链路收敛为“只读取项目根 `om_preset.lua`”；`xmake init_workspace` 会在项目壳中创建本地 `oh-my-robot` 目录链接/junction，并自动落一份项目级 `om_preset.lua` 模板；新增 `--preset=<path>` 后，可直接把指定 preset 源文件复制到项目壳根目录；`docs/process/git_collaboration_spec.md` 已补充“外部 worktree 开发 + 外层项目根独立构建”的推荐用法，`quick_start.md` 收回到项目根首次构建口径。
+- 2026-05-23：`xmake flash` 重构为策略模式，新增 DAPLink (OpenOCD) 烧录器支持。`flash` 预设格式升级：新增 `flash.flasher` 通用字段与 `flash.daplink` 子表，通用字段（`target`/`firmware`/`prefer_hex`/`reset`/`run`/`native_output`）提升至 `flash` 层级对两种烧录器均生效。同步更新全部构建文档与 VSCode 调试模板。
+- 2026-03-26：preset 解析链路收敛为”只读取项目根 `om_preset.lua`”；`xmake init_workspace` 会在项目壳中创建本地 `oh-my-robot` 目录链接/junction，并自动落一份项目级 `om_preset.lua` 模板；新增 `--preset=<path>` 后，可直接把指定 preset 源文件复制到项目壳根目录；`docs/process/git_collaboration_spec.md` 已补充“外部 worktree 开发 + 外层项目根独立构建”的推荐用法，`quick_start.md` 收回到项目根首次构建口径。
 - 2026-02-19：LTO 在 debug/release 统一纳入策略控制；收敛为“gnu-rm 按版本门槛启用（>=14.2.0）、armclang 默认开启”，并在 `oh_my_robot.context` 按工具链显式注入 LTO 参数。
 - 2026-02-19：根 `xmake.lua` 使用官方策略 `set_policy("build.optimization.lto", false)` 作为统一入口，具体目标开关由 `oh_my_robot.context` 依据工具链动态设置，避免模式与工具链行为分叉。
 - 2026-02-18：将 `tar_oh_my_robot`、`tar_osal` 收敛为聚合目标（`phony`），并新增二进制构建后的 OSAL/SYNC 关键符号链接契约校验。

--- a/docs/build/reference_manual.md
+++ b/docs/build/reference_manual.md
@@ -133,17 +133,23 @@ local preset = {
   board = {name = "rm-c-board"},
   os = {name = "freertos"},
   flash = {
+    flasher = "jlink",
+    target = "robot_project",
+    firmware = nil,
+    prefer_hex = true,
+    reset = true,
+    run = true,
+    native_output = false,
     jlink = {
       device = "STM32F407IG",
       interface = "swd",
       speed = 4000,
       program = "D:/Program Files/ProgramTools/SEGGER/Jlink/JLink.exe",
-      target = "robot_project",
-      firmware = nil,
-      prefer_hex = true,
-      reset = true,
-      run = true,
-      native_output = false,
+    },
+    daplink = {
+      program = "D:/openocd-win/bin/openocd.exe",
+      config = ".vscode/daplink.cfg",
+      frequency = 4000,
     },
   },
 }
@@ -155,8 +161,9 @@ end
 约束：
 - 仅用于选择与路径配置，不用于新增 board/os/toolchain 数据。
 - `toolchain_default.name` 和 `toolchain_presets` 的键必须在内置数据中存在。
-- `flash.jlink` 仅在 `xmake flash` 任务中读取，不影响常规构建流程。
-- 当前 `om_preset.flash` 仅支持 `jlink` 配置；`daplink` 处于规划阶段，尚未接入任务链路。
+- `flash` 配置在 `xmake flash` 任务中读取，不影响常规构建流程。
+- `om_preset.flash` 同时支持 `jlink` 与 `daplink` 两种调试器；通过 `flash.flasher` 指定默认类型，命令行 `--flasher=...` 可覆盖。
+- 通用字段（`target`/`firmware`/`prefer_hex`/`reset`/`run`/`native_output`）对两种烧录器均生效。
 
 ### 8.1 项目根与框架根
 - 项目根：当前顶层 `xmake.lua` 所在目录，也是 `compile_commands.json` 与构建产物的默认落点。
@@ -172,12 +179,12 @@ end
 | 概念 | 来源 | 示例 | 规则 |
 | --- | --- | --- | --- |
 | 目标名（Target ID） | `xmake.lua` 的 `target("...")` | `target("robot_project")` | 这是目标唯一标识 |
-| 烧录目标名 | `om_preset.lua` 的 `flash.jlink.target` | `target = "robot_project"` | 必须与 `target("...")` 完全一致 |
+| 烧录目标名 | `om_preset.lua` 的 `flash.target` | `target = "robot_project"` | 必须与 `target("...")` 完全一致 |
 | 输出文件名 | `xmake.lua` 的 `set_filename("...")` | `set_filename("robot_project.elf")` | 仅决定产物文件名 |
 | 调试符号文件 | `.vscode/launch.json` 的 `executable` | `build/cross/arm/debug/robot_project.elf` | 必须指向实际生成的 ELF |
 
 常见错配后果：
-- `flash.jlink.target` 与 `target("...")` 不一致：`xmake flash` 无法定位目标。
+- `flash.target` 与 `target("...")` 不一致：`xmake flash` 无法定位目标。
 - `launch.json.executable` 与真实产物不一致：Cortex-Debug 启动失败或符号加载失败。
 
 ## 9. 构建产物与清理
@@ -209,8 +216,8 @@ xmake clean
   - 生成项目壳：`xmake init_workspace --output=<dir>`。
   - 编辑项目根 `om_preset.lua`，填写当前项目使用的 `sdk/bin` 与烧录参数。
   - 进入项目壳后再执行 `xmake f -c -m debug` 与 `xmake`。
-- 烧录：`xmake flash` 通过 J-Link Commander 烧录，默认优先使用 HEX，可通过 `--firmware` 指定 ELF/HEX，并可用 `--native_output=true` 透传原生输出。
-- 调试器支持范围：当前仅支持 J-Link；DAPLink 为后续规划项（当前版本不可用）。
+- 烧录：`xmake flash` 通过策略模式支持 J-Link 与 DAPLink (OpenOCD) 两种烧录器，通过 `--flasher` 切换。默认优先使用 HEX，可通过 `--firmware` 指定 ELF/HEX，并可用 `--native_output=true` 透传原生输出。
+- 调试器支持范围：同时支持 J-Link 与 DAPLink (OpenOCD + CMSIS-DAP)。VSCode 调试通过 Cortex-Debug 插件，J-Link 使用 `servertype: "jlink"`，DAPLink 使用 `servertype: "openocd"`。
 - 更换板级/OS/工具链：重新执行 `xmake f -c --board=... --os=... --toolchain=...`。
 - 关闭镜像生成：从目标规则中移除 `oh_my_robot.image_convert`。
 - 禁用同步加速：`xmake f -c --sync_accel=none ...`。
@@ -308,7 +315,7 @@ xmake clean
 | `name` | 配置显示名称 | 建议包含探针/芯片/工具链，便于选择 |
 | `type` | 调试插件类型 | Cortex-Debug 固定为 `cortex-debug` |
 | `request` | 调试请求类型 | 启动并下载通常用 `launch` |
-| `servertype` | GDB Server 类型 | J-Link 链路固定 `jlink` |
+| `servertype` | GDB Server 类型 | J-Link 用 `jlink`；DAPLink 用 `openocd` |
 | `device` | 目标芯片型号 | 必须与探针端识别名称一致 |
 | `interface` | 调试接口 | 常用 `swd` |
 | `cwd` | 命令执行工作目录 | 固定 `${workspaceFolder}`，避免路径转义问题 |

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -130,6 +130,18 @@ DAPLink 探针要求：
 - 支持 CMSIS-DAP 协议的调试探针（如 DAP-WL-HS、Segger J-Link CMSIS-DAP 模式等）。
 - 若有多探针，需在 OpenOCD 配置文件中通过 `adapter serial` 指定目标探针序列号。
 
+DAPLink 配置文件准备：
+- 模板文件位于 `tools/openocd/daplink.cfg.example`。
+- 复制到项目根 `.vscode/daplink.cfg` 并按以下步骤修改：
+  1. 查找探针序列号：
+     ```powershell
+     openocd -c "adapter driver cmsis-dap; init; exit" 2>&1 | findstr /I "serial"
+     ```
+     或直接启动 openocd 后观察启动日志中的 `Info : CMSIS-DAP: ... (serial: 5627220232)` 行。
+  2. 将序列号填入 `adapter serial` 行（去掉行首的 `#` 注释）。
+  3. 若芯片不是 STM32F4 系列，修改 `source [find target/stm32f4x.cfg]` 为对应目标配置。
+- 单探针环境可省略 `adapter serial` 行。
+
 ## 2. 在项目根目录编写 `xmake.lua`
 
 文件位置：

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -108,8 +108,27 @@ arm-none-eabi-gdb --version
 ```
 
 说明：
-- 当前仓库调试链路默认使用 J-Link。
-- DAPLink 为后续规划，当前版本不提供可用模板。
+- 当前仓库调试链路支持 J-Link 与 DAPLink (OpenOCD) 两种调试器。
+
+### 1.7 OpenOCD（DAPLink 调试/烧录）
+下载入口（官方）：
+- <https://openocd.org/pages/getting-openocd.html>
+
+安装建议：
+- 下载 Windows 预编译包，解压到不含中文和空格的目录，例如 `D:/openocd-win`。
+- 可执行文件路径：`D:/openocd-win/bin/openocd.exe`。
+
+验证命令（PowerShell）：
+```powershell
+openocd --version
+```
+
+期望结果：
+- 能输出版本信息（建议 `0.12.0` 及以上）。
+
+DAPLink 探针要求：
+- 支持 CMSIS-DAP 协议的调试探针（如 DAP-WL-HS、Segger J-Link CMSIS-DAP 模式等）。
+- 若有多探针，需在 OpenOCD 配置文件中通过 `adapter serial` 指定目标探针序列号。
 
 ## 2. 在项目根目录编写 `xmake.lua`
 
@@ -219,19 +238,25 @@ local preset = {
     },
   },
 
-  -- 烧录器预设：当前仅支持 jlink
+  -- 烧录器预设
   flash = {
+    flasher = "jlink",                -- 默认烧录器：jlink / daplink
+    target = "robot_project",
+    firmware = nil,
+    prefer_hex = true,
+    reset = true,
+    run = true,
+    native_output = false,
     jlink = {
       device = "STM32F407IG",
       interface = "swd",
       speed = 4000,
       program = "D:/Program Files/ProgramTools/SEGGER/Jlink/JLink.exe", -- 找不到 JLink 时请改
-      target = "robot_project",
-      firmware = nil,
-      prefer_hex = true,
-      reset = true,
-      run = true,
-      native_output = false,
+    },
+    daplink = {
+      program = "D:/openocd-win/bin/openocd.exe",   -- 找不到 openocd 时请改
+      config = ".vscode/daplink.cfg",               -- OpenOCD 配置文件路径
+      frequency = 4000,
     },
   },
 }
@@ -242,9 +267,10 @@ end
 ```
 
 ### 3.3 重要说明：当前调试器支持范围
-- `om_preset.flash` 当前只消费 `flash.jlink`。
-- 当前版本不支持 `flash.daplink`。
-- 后续计划支持 DAPLink（当前处于规划阶段，尚未接入构建任务）。
+- `om_preset.flash` 同时支持 `flash.jlink` 与 `flash.daplink` 两种调试器。
+- 通过 `flash.flasher` 字段指定默认烧录器（`"jlink"` 或 `"daplink"`），命令行 `--flasher=...` 可覆盖。
+- J-Link 使用 JLink.exe 命令行工具烧录；DAPLink 使用 OpenOCD 烧录。
+- 通用字段（`target`/`firmware`/`prefer_hex`/`reset`/`run`/`native_output`）对两种烧录器均生效。
 
 ### 3.4 每个常用参数是什么意思
 参数优先级（非常重要）：
@@ -262,19 +288,24 @@ end
 | `toolchain_default.name` | 默认使用哪个工具链 | 可按习惯改 |
 | `toolchain_presets.<name>.sdk` | 工具链根目录 | 通常必须改成你本机路径 |
 | `toolchain_presets.<name>.bin` | 工具链可执行目录 | 通常必须改成你本机路径 |
+| `flash.flasher` | 默认烧录器类型 | 可选 `"jlink"` / `"daplink"` |
+| `flash.target` | 烧录目标名（XMake 目标名） | 必须与 `target("...")` 一致 |
+| `flash.firmware` | 手工指定固件路径 | 一般留空，自动选产物 |
+| `flash.prefer_hex` | 自动选择固件时优先 HEX | 一般保留 `true` |
+| `flash.reset` | 烧录前后是否复位 | 一般保留 `true` |
+| `flash.run` | 烧录后是否运行 | 调试停机时可改 |
+| `flash.native_output` | 是否显示原生 CLI 输出 | 排错时改为 `true` |
 | `flash.jlink.device` | 芯片名（J-Link 用） | 芯片变化时改 |
 | `flash.jlink.interface` | 调试接口（如 `swd`） | 一般不改 |
 | `flash.jlink.speed` | 下载速度（kHz） | 速度不稳时改 |
 | `flash.jlink.program` | `JLink.exe` 路径 | 自动发现失败时改 |
-| `flash.jlink.target` | 烧录目标名（XMake 目标名） | 必须与 `target("...")` 一致 |
-| `flash.jlink.firmware` | 手工指定固件路径 | 一般留空，自动选产物 |
-| `flash.jlink.prefer_hex` | 自动选择固件时优先 HEX | 一般保留 `true` |
-| `flash.jlink.reset` | 烧录前后是否复位 | 一般保留 `true` |
-| `flash.jlink.run` | 烧录后是否运行 | 调试停机时可改 |
-| `flash.jlink.native_output` | 是否显示原生 CLI 输出 | 排错时改为 `true` |
+| `flash.daplink.program` | `openocd.exe` 路径 | 自动发现失败时改 |
+| `flash.daplink.config` | OpenOCD 配置文件路径 | 按探针类型修改 |
+| `flash.daplink.frequency` | 适配器频率（Hz） | 速度不稳时改 |
 
 兼容项说明：
-- `flash.file` 与 `flash.firmware` 都可识别，但新配置建议只用 `flash.jlink.firmware`。
+- `flash.file` 与 `flash.firmware` 都可识别，但新配置建议只用 `flash.firmware`。
+- 旧格式（`flash.jlink` 内直接写 `target`/`firmware` 等通用字段）仍然兼容，但推荐将通用字段提升到 `flash` 层级。
 
 ### 3.5 写完后怎么确认没写错
 ```powershell
@@ -289,9 +320,13 @@ xmake f -c --toolchain=armclang -m debug --semihosting=off
 ```powershell
 xmake flash --native_output=true
 ```
+- 若需使用 DAPLink 烧录：
+```powershell
+xmake flash --flasher=daplink
+```
 
-### 3.6 `flash.jlink.target` 到底要填什么（高频混淆）
-- `flash.jlink.target` 填的是 **XMake 目标名**，不是文件名。
+### 3.6 `flash.target` 到底要填什么（高频混淆）
+- `flash.target` 填的是 **XMake 目标名**，不是文件名。
 - 在本项目里，它应当与 `xmake.lua` 里的 `target("robot_project")` 保持一致。
 - 它不等于 `set_filename("robot_project.elf")` 里的文件名。
 
@@ -307,7 +342,7 @@ xmake flash --native_output=true
 步骤 2：创建文件 `.vscode/launch.json`。  
 步骤 3：粘贴以下模板并按注释改路径。
 
-### 4.3 双工具链模板（可直接复制）
+### 4.3 多调试器模板（可直接复制）
 ```json
 {
   "version": "0.2.0",
@@ -352,6 +387,38 @@ xmake flash --native_output=true
         "monitor semihosting breakonerror 0",
         "set mem inaccessible-by-default off"
       ]
+    },
+    {
+      "name": "Debug (OpenOCD / DAPLink)",
+      "type": "cortex-debug",
+      "request": "launch",
+      "servertype": "openocd",
+      "cwd": "${workspaceFolder}",
+      "executable": "build/cross/cortex-m4/debug/robot_project.elf",
+      "serverpath": "D:/openocd-win/bin/openocd.exe",
+      "configFiles": [
+        "${workspaceFolder}/.vscode/daplink.cfg"
+      ],
+      "gdbPath": "D:/Toolchains/gcc-arm-none-eabi-10.3-2021.10/bin/arm-none-eabi-gdb",
+      "svdFile": "${workspaceFolder}/oh-my-robot/platform/bsp/vendor/STM32/STM32F4/SVD/STM32F407.svd",
+      "runToEntryPoint": "main",
+      "preLaunchTask": "xmake-build-debug",
+      "showDevDebugOutput": "none"
+    },
+    {
+      "name": "Attach (OpenOCD / DAPLink)",
+      "type": "cortex-debug",
+      "request": "attach",
+      "servertype": "openocd",
+      "cwd": "${workspaceFolder}",
+      "executable": "build/cross/cortex-m4/debug/robot_project.elf",
+      "serverpath": "D:/openocd-win/bin/openocd.exe",
+      "configFiles": [
+        "${workspaceFolder}/.vscode/daplink.cfg"
+      ],
+      "gdbPath": "D:/Toolchains/gcc-arm-none-eabi-10.3-2021.10/bin/arm-none-eabi-gdb",
+      "svdFile": "${workspaceFolder}/oh-my-robot/platform/bsp/vendor/STM32/STM32F4/SVD/STM32F407.svd",
+      "showDevDebugOutput": "none"
     }
   ]
 }
@@ -360,21 +427,29 @@ xmake flash --native_output=true
 ### 4.4 关键参数怎么填（新手版）
 | 参数 | 作用 | 你通常需要改什么 |
 | --- | --- | --- |
-| `name` | 调试配置显示名 | 建议保留，便于区分 gcc/armclang |
+| `name` | 调试配置显示名 | 建议保留，便于区分调试器/工具链 |
 | `type` | 调试器插件类型 | 固定 `cortex-debug` |
-| `servertype` | GDB Server 类型 | 当前固定 `jlink` |
-| `device` | 目标芯片名 | 芯片变化时改 |
+| `servertype` | GDB Server 类型 | J-Link 用 `jlink`；DAPLink 用 `openocd` |
+| `device` | 目标芯片名（J-Link） | 芯片变化时改 |
 | `executable` | 符号 ELF 路径 | 切换工具链或 profile 时改 |
-| `serverpath` | `JLinkGDBServerCL.exe` 路径 | 通常按本机安装路径改 |
-| `armToolchainPath` | `arm-none-eabi-gdb` 所在目录 | 按本机路径改 |
+| `serverpath` | GDB Server 可执行路径 | J-Link: `JLinkGDBServerCL.exe`；OpenOCD: `openocd.exe` |
+| `configFiles` | OpenOCD 配置文件列表 | DAPLink 调试时必填 |
+| `gdbPath` | `arm-none-eabi-gdb` 完整路径 | OpenOCD 链路需显式指定 |
+| `armToolchainPath` | `arm-none-eabi-gdb` 所在目录 | J-Link 链路使用，按本机路径改 |
 | `overrideLaunchCommands` | 自定义下载链路 | armclang 推荐 `restore ...hex` |
 | `preLaunchCommands` | 调试前命令 | semihosting 场景按需调整 |
+| `preLaunchTask` | 调试前构建任务 | 可选，用于自动编译后启动调试 |
 
 ### 4.5 常见坑与处理
 - `Failed to launch GDB`：
-  - 检查 `armToolchainPath` 是否是 `arm-none-eabi-gdb` 所在目录。
+  - J-Link 链路：检查 `armToolchainPath` 是否是 `arm-none-eabi-gdb` 所在目录。
+  - OpenOCD 链路：检查 `gdbPath` 是否为 `arm-none-eabi-gdb` 完整路径。
 - `JLinkGDBServerCL.exe` 找不到：
   - 检查 `serverpath` 是否为本机真实路径。
+- OpenOCD 启动失败 / 探针无法连接：
+  - 检查 `configFiles` 中 OpenOCD 配置文件路径是否正确。
+  - 若有多探针，确保在 `.cfg` 文件中配置了 `adapter serial` 指定目标探针。
+  - 执行 `openocd -f .vscode/daplink.cfg` 检查原生输出定位问题。
 - `armclang` 下载后异常：
   - 优先使用 `restore ...robot_project.hex`，不要直接套用 `load`。
 - 停在 semihosting 相关 BKPT：
@@ -382,21 +457,23 @@ xmake flash --native_output=true
   - 若构建使用 `--semihosting=off`，可移除 semihosting 相关命令，仅保留 `set mem inaccessible-by-default off`。
 
 ### 4.6 与 `om_preset.lua` 的关系
-- `om_preset.lua`：决定构建与烧录默认参数（例如工具链路径、J-Link 参数）。
+- `om_preset.lua`：决定构建与烧录默认参数（例如工具链路径、J-Link/OpenOCD 参数）。
 - `.vscode/launch.json`：决定 VSCode 调试时如何连接并加载程序。
-- 两边路径都要指向你本机真实安装位置。
+- `.vscode/daplink.cfg`：OpenOCD 配置文件，指定调试探针与目标芯片。
+- 各文件路径都要指向你本机真实安装位置。
 
 ### 4.7 跨模块 `name` 映射关系（必须一致的部分）
 | 概念 | 配置位置 | 示例 | 关系规则 |
 | --- | --- | --- | --- |
-| XMake 目标名 | `xmake.lua` 的 `target("...")` | `target("robot_project")` | 这是“目标 ID”，给 `xmake flash --target=...` 与 `flash.jlink.target` 使用 |
-| 烧录目标名 | `om_preset.lua` 的 `flash.jlink.target` | `target = "robot_project"` | 必须与 `target("...")` 完全一致 |
-| 输出文件名 | `xmake.lua` 的 `set_filename("...")` | `set_filename("robot_project.elf")` | 仅决定产物文件名，不参与目标查找 |
+| XMake 目标名 | `xmake.lua` 的 `target(“...”)` | `target(“robot_project”)` | 这是”目标 ID”，给 `xmake flash --target=...` 与 `flash.target` 使用 |
+| 烧录目标名 | `om_preset.lua` 的 `flash.target` | `target = “robot_project”` | 必须与 `target(“...”)` 完全一致 |
+| 输出文件名 | `xmake.lua` 的 `set_filename(“...”)` | `set_filename(“robot_project.elf”)` | 仅决定产物文件名，不参与目标查找 |
 | 调试符号文件路径 | `.vscode/launch.json` 的 `executable` | `build/cross/arm/debug/robot_project.elf` | 必须指向 `set_filename` 生成的真实 ELF 路径 |
-| 调试配置显示名 | `.vscode/launch.json` 的 `name` | `J-Link | STM32F407IG | gcc` | 仅用于界面显示，与构建/烧录逻辑无绑定 |
+| OpenOCD 配置 | `.vscode/daplink.cfg` | `adapter serial 5627220232` | 指定 CMSIS-DAP 探针序列号与目标芯片 |
+| 调试配置显示名 | `.vscode/launch.json` 的 `name` | `Debug (OpenOCD / DAPLink)` | 仅用于界面显示，与构建/烧录逻辑无绑定 |
 
 快速判断是否填错：
-- `xmake flash` 报 “target not found”：先检查 `flash.jlink.target` 与 `target("...")` 是否一致。
+- `xmake flash` 报 “target not found”：先检查 `flash.target` 与 `target(“...”)` 是否一致。
 - VSCode 报找不到可执行文件：先检查 `launch.json` 的 `executable` 是否对应 `set_filename(...)` 的实际输出路径。
 
 ## 5. 新手常见错误

--- a/om_preset.example.lua
+++ b/om_preset.example.lua
@@ -18,17 +18,23 @@ local preset = {
     },
   },
   flash = {
+    flasher = "jlink",                -- 默认烧录器：jlink / daplink
+    target = "robot_project",
+    firmware = nil,
+    prefer_hex = true,
+    reset = true,
+    run = true,
+    native_output = false,
     jlink = {
       device = "STM32F407IG",
       interface = "swd",
       speed = 4000,
       program = "D:/Program Files/ProgramTools/SEGGER/Jlink/JLink.exe",
-      target = "robot_project",
-      firmware = nil,
-      prefer_hex = true,
-      reset = true,
-      run = true,
-      native_output = false,
+    },
+    daplink = {
+      program = "D:/openocd-win/bin/openocd.exe",
+      config = ".vscode/daplink.cfg",
+      frequency = 4000,
     },
   },
 }

--- a/tools/openocd/daplink.cfg.example
+++ b/tools/openocd/daplink.cfg.example
@@ -1,0 +1,16 @@
+# OpenOCD config template for CMSIS-DAP probes (DAPLink)
+#
+# 使用说明：
+# 1. 复制此文件到项目 workspace 的 .vscode/daplink.cfg
+# 2. 运行以下命令查找你的探针序列号：
+#    openocd -c "adapter driver cmsis-dap; init; exit"
+#    或观察 OpenOCD 启动日志中 "adapter serial" 的输出
+# 3. 将下方 adapter serial 后面的序列号替换为你的探针序列号
+# 4. 确认 target/stm32f4x.cfg 适用于你的芯片（STM32F4 系列通用；
+#    其他系列请修改为对应的 target 配置，如 target/stm32f1x.cfg）
+
+adapter driver cmsis-dap
+# adapter serial 5627220232       # <-- 请改为你的探针序列号（去掉行首 #）
+transport select swd
+source [find target/stm32f4x.cfg]
+adapter speed 4000


### PR DESCRIPTION
## 概要

1. **重构 flash 任务为策略模式并新增 DAPLink (OpenOCD) 烧录/调试支持** (`ae1a656`)
2. **添加 daplink.cfg 模板文件与配置说明** (`ba6d085`)
3. **修复 armclang ELF .data LMA 导致调试时全局变量初始化失败** (`183e2cf`)

## armclang ELF 修复详解

### 根因

armlink 生成的 ELF 仅包含 1 个 LOAD segment（ER_IROM1），RW_IRAM1 sections (VMA=0x20000000) 落在所有 LOAD segment 之外。GDB `load` 命令回退到使用 `sh_addr` (VMA/RAM) 而非正确的 LMA (flash)，导致 .data 初始化值被写入 RAM 而非 flash。MCU 复位后 scatter-loading 将擦除态 (0xFF) 从 flash 复制到 RAM，覆盖 GDB 写入的值，全局变量显示 0xFFFFFFFF。

### 修复方案

`after_build` 阶段对 armclang ELF 进行二进制后处理（纯 Lua 实现，零外部依赖）：
- 解析 ELF32 结构，遍历 section headers 找到 RW_IRAM1 PROGBITS section
- 从文件偏移计算 flash LMA
- 构建新的 LOAD program header（VMA=0x20000000, LMA=flash_addr）
- 插入到现有 program headers 之后，更新 `e_phnum` 和 `e_shoff`

修补后 ELF 包含 2 个 LOAD segment，GDB 正确加载 .data 到 flash LMA。

### 验证

在 STM32F427IIHx 硬件上通过 DAPLink + OpenOCD + GDB 实测确认：
- `gBspCan[0].handle.Instance` = 0x40006400 (CAN1 base) ✓
- `g_bsp_serial[0].handle.Instance` = 0x40011000 (USART1 base) ✓
- `readelf -l` 显示 2 个 LOAD segment，第 2 个 VMA=0x20000000 PhysAddr=0x080xxxxx ✓

## 测试计划

- [x] armclang 构建 + DAPLink/OpenOCD 硬件调试验证
- [ ] CI 通过 armclang 和 gnu-rm 双工具链构建