### PR TITLE
fix(data_struct): 修复 ringbuf_init 非2的幂容量导致死循环

### DIFF
--- a/lib/data_struct/src/ringbuffer.c
+++ b/lib/data_struct/src/ringbuffer.c
@@ -3,19 +3,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define IS_NUM_POWER_OF_TWO(x) ((x) && !(((x) & ((x) - 1U))))
-
 bool ringbuf_init(Ringbuf *rb, uint8_t *buff, unsigned int item_size, unsigned int item_count)
 {
     if ((rb == NULL) || (buff == NULL) || (item_size == 0U) || (item_count == 0U))
         return false;
 
-    if (!IS_NUM_POWER_OF_TWO(item_count))
-    {
-        while (1)
-        {
-        }
-    }
+    item_count = roundup_pow_of_two(item_count);
 
     rb->buf = buff;
     rb->esize = item_size;

--- a/samples/host/ringbuf/ringbuffer_concurrency_main.c
+++ b/samples/host/ringbuf/ringbuffer_concurrency_main.c
@@ -80,6 +80,25 @@ static int run_ringbuffer_basic_test(void)
     return 1;
 }
 
+/* A1: 非 2 的幂容量不挂死，自动向上取整 */
+static int run_ringbuffer_non_power_of_two_test(void)
+{
+    Ringbuf rb;
+    uint32_t storage[16] = {0};
+    unsigned int cap;
+
+    memset(&rb, 0, sizeof(rb));
+    /* 传入 3，应自动取整为 4，不挂死 */
+    if (!ringbuf_init(&rb, (uint8_t*)storage, sizeof(uint32_t), 3))
+        return 0;
+
+    cap = ringbuf_cap(&rb);
+    if (cap != 4)
+        return 0;
+
+    return 1;
+}
+
 #ifdef _WIN32
 static int host_thread_create(HostThread* thread, LPTHREAD_START_ROUTINE entry, void* arg)
 {
@@ -238,6 +257,7 @@ static int run_ringbuffer_concurrency_test(void)
 int main(void)
 {
     int basicOk = run_ringbuffer_basic_test();
+    int pow2Ok = run_ringbuffer_non_power_of_two_test();
     int concurOk = run_ringbuffer_concurrency_test();
 
     if (!basicOk)
@@ -247,10 +267,17 @@ int main(void)
     }
     printf("[PASS] ringbuffer basic test passed\n");
 
+    if (!pow2Ok)
+    {
+        printf("[FAIL] ringbuffer non-power-of-two init test failed\n");
+        return 2;
+    }
+    printf("[PASS] ringbuffer non-power-of-two init test passed\n");
+
     if (!concurOk)
     {
         printf("[FAIL] ringbuffer concurrency test failed\n");
-        return 2;
+        return 5;
     }
     printf("[PASS] ringbuffer concurrency test passed\n");
 


### PR DESCRIPTION
## 改动

将 `ringbuf_init()` 中非 2 的幂容量触发的 `while(1){}` 死循环替换为 `roundup_pow_of_two()` 自动向上取整，与 `ringbuf_alloc()` 行为统一。

## 动机

原代码在 `ringbuf_init(&rb, buf, item_size, 3)` 时会直接挂死 CPU，无错误返回、无诊断输出。`ringbuf_alloc()` 已通过 `roundup_pow_of_two()` 优雅处理此场景，`ringbuf_init()` 应与之一致。

## 具体变更

- **ringbuffer.c**: `while(1){}` → `item_count = roundup_pow_of_two(item_count)`
- **ringbuffer.c**: 删除不再使用的 `IS_NUM_POWER_OF_TWO` 宏
- **测试**: 新增 `run_ringbuffer_non_power_of_two_test()` 验证非 2 的幂容量（如 3）初始化不挂死且容量正确取整为 4

## 测试

```
[PASS] ringbuffer basic test passed
[PASS] ringbuffer non-power-of-two init test passed
[PASS] ringbuffer concurrency test passed
```