### PR TITLE
feat(data_struct): 新增 DoubleBuf 乒乓双缓冲区

### DIFF
--- a/lib/data_struct/include/data_struct/data_struct.h
+++ b/lib/data_struct/include/data_struct/data_struct.h
@@ -3,6 +3,7 @@
 
 #include "avltree.h"
 #include "corelist.h"
+#include "double_buf.h"
 #include "mpsc_ringbuf.h"
 #include "ringbuffer.h"
 

--- a/lib/data_struct/include/data_struct/double_buf.h
+++ b/lib/data_struct/include/data_struct/double_buf.h
@@ -1,0 +1,280 @@
+#ifndef DATA_STRUCT_DOUBLE_BUF_H
+#define DATA_STRUCT_DOUBLE_BUF_H
+
+#include "atomic/atomic_simple.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @brief 双缓冲区（Ping-Pong Buffer）
+ *
+ * 将一块连续内存（或两块独立内存）从逻辑上分割为两个等大的 page，
+ * 分别称为 Page 0（低地址）和 Page 1（高地址）。
+ *
+ * 角色由 idx 决定：
+ *   - 写 page = page[idx]  （生产者写入）
+ *   - 读 page = page[idx^1]（消费者读取）
+ *
+ * 生产者调用 commit() 翻转 idx，使得刚写完的 page 对消费者可见。
+ * 生产者永不阻塞——若消费者未及时消费旧帧，旧帧被静默丢弃，
+ * drop_cnt 递增供诊断。
+ *
+ * 适用场景：DMA 双缓冲、串口/USB CDC 收帧、Sensor 数据采集等
+ * SPSC（单生产者/单消费者）场景。
+ *
+ * @note  双缓冲不是队列。若需无丢数据的流式传输，请使用 Ringbuf 或 Pipe。
+ *
+ * 典型用法（零拷贝——DMA / ISR）：
+ * @code
+ *   uint8_t mem[512];
+ *   DoubleBuf db;
+ *   dbuf_init(&db, mem, 256);
+ *
+ *   // 生产者（ISR）
+ *   uint8_t *buf = dbuf_get_write_ptr(&db);
+ *   buf[pos++] = uart_read_byte();
+ *   dbuf_commit(&db, pos);
+ *
+ *   // 消费者（任务）
+ *   size_t len;
+ *   uint8_t *data = dbuf_get_read_ptr(&db, &len);
+ *   if (data) { process(data, len); dbuf_consume(&db); }
+ * @endcode
+ *
+ * 典型用法（拷贝——简单场景）：
+ * @code
+ *   // 生产者
+ *   dbuf_write(&db, src_data, src_len);
+ *
+ *   // 消费者
+ *   uint8_t buf[256];
+ *   size_t n = dbuf_read(&db, buf, sizeof(buf));
+ *   if (n) process(buf, n);
+ * @endcode
+ *
+ * 与其他模块对比：
+ *   - Ringbuf   : 流式 FIFO， 不丢数据，需拷贝进出，容量 N
+ *   - Pipe      : Ringbuf + 信号量，阻塞式流式传输
+ *   - DoubleBuf : 帧式，零拷贝，最新覆盖，容量恒为 2
+ */
+typedef struct DoubleBuf
+{
+    uint8_t     *page[2];    /**< page[0]: Page 0（低地址），page[1]: Page 1（高地址） */
+    size_t       page_size;  /**< 单个 page 的字节大小 */
+    OmAtomicUint idx;        /**< 当前写 page 索引 (0 或 1)；读 page 索引为 idx ^ 1 */
+    size_t       len[2];     /**< len[0]: Page 0 有效数据, len[1]: Page 1 有效数据 */
+    OmAtomicUint drop_cnt;   /**< 被覆盖丢弃的帧计数 */
+    bool         owned;      /**< 内存是否由 dbuf_alloc 动态分配 */
+} DoubleBuf;
+
+/*===========================================================================
+ * 初始化 / 销毁
+ *===========================================================================*/
+
+/**
+ * @brief 用一块连续内存初始化双缓冲区（主接口）
+ * @param db        双缓冲区对象指针
+ * @param mem       连续内存块，大小 >= 2 * page_size
+ * @param page_size 单个 page 的字节大小（> 0）
+ * @return true 成功，false 参数非法
+ */
+bool dbuf_init(DoubleBuf *db, void *mem, size_t page_size);
+
+/**
+ * @brief 用两块独立内存初始化双缓冲区
+ * @param db        双缓冲区对象指针
+ * @param page0     Page 0 内存，大小 >= page_size
+ * @param page1     Page 1 内存，大小 >= page_size
+ * @param page_size 单个 page 的字节大小（> 0）
+ * @return true 成功，false 参数非法
+ */
+bool dbuf_init_split(DoubleBuf *db, void *page0, void *page1, size_t page_size);
+
+/**
+ * @brief 动态分配双缓冲区（内部分配 2 * page_size 连续内存）
+ * @note  嵌入式堆易碎片化，优先使用 dbuf_init（静态/栈内存）。
+ * @param db        双缓冲区对象指针
+ * @param page_size 单个 page 的字节大小（> 0）
+ * @param pmalloc   自定义分配函数，传 NULL 使用 malloc
+ * @return true 成功，false 内存不足或参数非法
+ */
+bool dbuf_alloc(DoubleBuf *db, size_t page_size, void *(*pmalloc)(size_t));
+
+/**
+ * @brief 释放动态分配的内存（仅 dbuf_alloc 创建的有效，split/init 模式无操作）
+ * @param db    双缓冲区对象指针
+ * @param pfree 自定义释放函数，传 NULL 使用 free
+ */
+void dbuf_free(DoubleBuf *db, void (*pfree)(void *));
+
+/*===========================================================================
+ * 生产者接口（写入侧）
+ *===========================================================================*/
+
+/**
+ * @brief 获取写 page 的指针（始终成功，永不阻塞）
+ * @param db 双缓冲区对象指针
+ * @return 写 page 起始地址，db 无效时返回 NULL
+ */
+uint8_t *dbuf_get_write_ptr(DoubleBuf *db);
+
+/**
+ * @brief 获取写 page 的容量
+ * @param db 双缓冲区对象指针
+ * @return page_size
+ */
+static inline size_t dbuf_get_write_size(DoubleBuf *db)
+{
+    return db->page_size;
+}
+
+/**
+ * @brief 提交写入的数据并交换 page 角色
+ * @param db  双缓冲区对象指针
+ * @param len 写入的有效数据长度（超过 page_size 时自动截断）
+ */
+void dbuf_commit(DoubleBuf *db, size_t len);
+
+/**
+ * @brief 仅交换 page 角色（适用于 DMA 等由硬件管理数据长度的场景）
+ * @param db 双缓冲区对象指针
+ */
+void dbuf_swap(DoubleBuf *db);
+
+/*===========================================================================
+ * 生产者接口（写入侧）——便捷拷贝
+ *===========================================================================*/
+
+/**
+ * @brief 将数据拷贝写入双缓冲区（便捷接口）
+ *
+ * 等价于 get_write_ptr + memcpy + commit。
+ * DMA / ISR 等需要零拷贝的场景请使用 get_write_ptr + commit。
+ *
+ * @param db   双缓冲区对象指针
+ * @param data 源数据指针
+ * @param len  数据长度（超过 page_size 时自动截断）
+ */
+static inline void dbuf_write(DoubleBuf *db, const void *data, size_t len)
+{
+    size_t n = (len < db->page_size) ? len : db->page_size;
+    memcpy(dbuf_get_write_ptr(db), data, n);
+    dbuf_commit(db, n);
+}
+
+/*===========================================================================
+ * 消费者接口（读取侧）——零拷贝
+ *===========================================================================*/
+
+/**
+ * @brief 获取读 page 的指针及有效数据长度
+ * @param db      双缓冲区对象指针
+ * @param out_len 输出参数，接收有效数据长度（可传 NULL）
+ * @return 读 page 起始地址，无数据则返回 NULL
+ */
+uint8_t *dbuf_get_read_ptr(DoubleBuf *db, size_t *out_len);
+
+/**
+ * @brief 标记读 page 中的数据已消费完毕
+ * @param db 双缓冲区对象指针
+ */
+void dbuf_consume(DoubleBuf *db);
+
+/*===========================================================================
+ * 消费者接口（读取侧）——便捷拷贝
+ *===========================================================================*/
+
+/**
+ * @brief 从双缓冲区拷贝读取数据（便捷接口）
+ *
+ * 等价于 get_read_ptr + memcpy + consume。
+ *
+ * @param db      双缓冲区对象指针
+ * @param dst     目标缓冲区
+ * @param max_len 最大读取长度
+ * @return 实际拷贝的字节数，无数据返回 0
+ */
+static inline size_t dbuf_read(DoubleBuf *db, void *dst, size_t max_len)
+{
+    size_t len;
+    uint8_t *src = dbuf_get_read_ptr(db, &len);
+    if (!src)
+        return 0U;
+    size_t n = (len < max_len) ? len : max_len;
+    memcpy(dst, src, n);
+    dbuf_consume(db);
+    return n;
+}
+
+/*===========================================================================
+ * 状态查询
+ *===========================================================================*/
+
+/**
+ * @brief 是否有数据可供读取
+ * @param db 双缓冲区对象指针
+ * @return true 有数据可读
+ */
+bool dbuf_is_data_ready(DoubleBuf *db);
+
+/**
+ * @brief 获取读 page 中的有效数据长度
+ * @param db 双缓冲区对象指针
+ * @return 有效数据长度（字节），无数据返回 0
+ */
+size_t dbuf_get_read_len(DoubleBuf *db);
+
+/**
+ * @brief 检查当前写入是否会触发丢帧
+ *
+ * 如果写 page 中仍有未消费数据，下一次 get_write_ptr 会丢弃它。
+ * 生产者可在写入前用此接口做选择性丢弃决策。
+ *
+ * @param db 双缓冲区对象指针
+ * @return true  写 page 空闲，写入不会丢帧
+ *         false 写 page 中有未消费数据，此时写入将导致丢帧
+ */
+bool dbuf_is_write_ready(DoubleBuf *db);
+
+/**
+ * @brief 获取单个 page 的容量
+ * @param db 双缓冲区对象指针
+ * @return page_size
+ */
+static inline size_t dbuf_capacity(DoubleBuf *db)
+{
+    return db->page_size;
+}
+
+/**
+ * @brief 获取被静默丢弃的帧计数
+ * @param db 双缓冲区对象指针
+ * @return 累计丢弃帧数
+ */
+static inline uint32_t dbuf_drop_count(DoubleBuf *db)
+{
+    return (uint32_t)OM_LOAD_RLX(&db->drop_cnt);
+}
+
+/*===========================================================================
+ * 管理接口
+ *===========================================================================*/
+
+/**
+ * @brief 重置双缓冲区到初始状态（丢弃所有未消费数据）
+ * @param db 双缓冲区对象指针
+ */
+void dbuf_flush(DoubleBuf *db);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* DATA_STRUCT_DOUBLE_BUF_H */

--- a/lib/data_struct/src/double_buf.c
+++ b/lib/data_struct/src/double_buf.c
@@ -1,0 +1,229 @@
+#include "data_struct/double_buf.h"
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*===========================================================================
+ * 初始化 / 销毁
+ *===========================================================================*/
+
+bool dbuf_init(DoubleBuf *db, void *mem, size_t page_size)
+{
+    if ((db == NULL) || (mem == NULL) || (page_size == 0U))
+        return false;
+
+    db->page[0] = (uint8_t *)mem;
+    db->page[1] = (uint8_t *)mem + page_size;
+    db->page_size = page_size;
+    db->len[0] = 0U;
+    db->len[1] = 0U;
+    db->owned = false;
+    OM_STORE_RLX(&db->idx, 0U);
+    OM_STORE_RLX(&db->drop_cnt, 0U);
+
+    return true;
+}
+
+bool dbuf_init_split(DoubleBuf *db, void *page0, void *page1, size_t page_size)
+{
+    if ((db == NULL) || (page0 == NULL) || (page1 == NULL) || (page_size == 0U))
+        return false;
+
+    db->page[0] = (uint8_t *)page0;
+    db->page[1] = (uint8_t *)page1;
+    db->owned = false;
+    db->page_size = page_size;
+    db->len[0] = 0U;
+    db->len[1] = 0U;
+    OM_STORE_RLX(&db->idx, 0U);
+    OM_STORE_RLX(&db->drop_cnt, 0U);
+
+    return true;
+}
+
+bool dbuf_alloc(DoubleBuf *db, size_t page_size, void *(*pmalloc)(size_t))
+{
+    uint8_t *mem;
+
+    if ((db == NULL) || (page_size == 0U))
+        return false;
+
+    if (!pmalloc)
+        mem = (uint8_t *)malloc(2U * page_size);
+    else
+        mem = (uint8_t *)pmalloc(2U * page_size);
+
+    if (mem == NULL)
+        return false;
+
+    memset(mem, 0, 2U * page_size);
+
+    db->page[0] = mem;
+    db->page[1] = mem + page_size;
+    db->page_size = page_size;
+    db->len[0] = 0U;
+    db->len[1] = 0U;
+    db->owned = true;
+    OM_STORE_RLX(&db->idx, 0U);
+    OM_STORE_RLX(&db->drop_cnt, 0U);
+
+    return true;
+}
+
+void dbuf_free(DoubleBuf *db, void (*pfree)(void *))
+{
+    if ((db == NULL) || (!db->owned) || (db->page[0] == NULL))
+        return;
+
+    if (!pfree)
+        free(db->page[0]);
+    else
+        pfree(db->page[0]);
+
+    db->page[0] = NULL;
+    db->page[1] = NULL;
+    db->page_size = 0U;
+    db->owned = false;
+}
+
+/*===========================================================================
+ * 生产者接口
+ *===========================================================================*/
+
+uint8_t *dbuf_get_write_ptr(DoubleBuf *db)
+{
+    unsigned int w_idx;
+
+    if (db == NULL)
+        return NULL;
+
+    w_idx = OM_LOAD_ACQ(&db->idx);
+
+    /*
+     * 写 page 中如果还有未消费数据，说明消费者没跟上。
+     * 在此处（生产者独占的写入侧）清零并计数，避免在 commit 中
+     * 与消费者的 get_read_ptr 产生竞争。
+     */
+    if (db->len[w_idx] != 0U)
+    {
+        OM_INC_RLX(&db->drop_cnt);
+        db->len[w_idx] = 0U;
+    }
+
+    return db->page[w_idx];
+}
+
+void dbuf_commit(DoubleBuf *db, size_t len)
+{
+    unsigned int w_idx;
+
+    if (db == NULL)
+        return;
+
+    w_idx = OM_LOAD_RLX(&db->idx);
+
+    if (len > db->page_size)
+        len = db->page_size;
+
+    db->len[w_idx] = len;
+
+    /* release idx 保证消费者通过 acquire 看到完整的 len[] 更新 */
+    OM_STORE_REL(&db->idx, w_idx ^ 1U);
+}
+
+void dbuf_swap(DoubleBuf *db)
+{
+    unsigned int w_idx;
+
+    if (db == NULL)
+        return;
+
+    w_idx = OM_LOAD_RLX(&db->idx);
+    OM_STORE_REL(&db->idx, w_idx ^ 1U);
+}
+
+/*===========================================================================
+ * 消费者接口
+ *===========================================================================*/
+
+uint8_t *dbuf_get_read_ptr(DoubleBuf *db, size_t *out_len)
+{
+    unsigned int r_idx;
+
+    if (db == NULL)
+        return NULL;
+
+    /* acquire idx 保证看到生产者在 commit 中设置的 len[] */
+    r_idx = OM_LOAD_ACQ(&db->idx) ^ 1U;
+
+    if (db->len[r_idx] == 0U)
+        return NULL;
+
+    if (out_len)
+        *out_len = db->len[r_idx];
+
+    return db->page[r_idx];
+}
+
+void dbuf_consume(DoubleBuf *db)
+{
+    unsigned int r_idx;
+
+    if (db == NULL)
+        return;
+
+    r_idx = OM_LOAD_ACQ(&db->idx) ^ 1U;
+    db->len[r_idx] = 0U;
+}
+
+/*===========================================================================
+ * 状态查询
+ *===========================================================================*/
+
+bool dbuf_is_data_ready(DoubleBuf *db)
+{
+    unsigned int r_idx;
+
+    if (db == NULL)
+        return false;
+
+    r_idx = OM_LOAD_ACQ(&db->idx) ^ 1U;
+    return db->len[r_idx] != 0U;
+}
+
+size_t dbuf_get_read_len(DoubleBuf *db)
+{
+    unsigned int r_idx;
+
+    if (db == NULL)
+        return 0U;
+
+    r_idx = OM_LOAD_ACQ(&db->idx) ^ 1U;
+    return db->len[r_idx];
+}
+
+bool dbuf_is_write_ready(DoubleBuf *db)
+{
+    unsigned int w_idx;
+
+    if (db == NULL)
+        return false;
+
+    w_idx = OM_LOAD_ACQ(&db->idx);
+    return db->len[w_idx] == 0U;
+}
+
+/*===========================================================================
+ * 管理接口
+ *===========================================================================*/
+
+void dbuf_flush(DoubleBuf *db)
+{
+    if (db == NULL)
+        return;
+
+    db->len[0] = 0U;
+    db->len[1] = 0U;
+    OM_STORE_RLX(&db->idx, 0U);
+    OM_STORE_RLX(&db->drop_cnt, 0U);
+}

--- a/samples/host/double_buf/double_buf_test.c
+++ b/samples/host/double_buf/double_buf_test.c
@@ -1,0 +1,164 @@
+#include "data_struct/double_buf.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#define PAGE_SZ 64
+
+static int test_basic_ping_pong(void)
+{
+    DoubleBuf db;
+    uint8_t mem[2 * PAGE_SZ];
+    assert(dbuf_init(&db, mem, PAGE_SZ));
+
+    assert(!dbuf_is_data_ready(&db));
+    assert(dbuf_get_read_ptr(&db, NULL) == NULL);
+
+    uint8_t *ptr = dbuf_get_write_ptr(&db);
+    memset(ptr, 0xAB, 32);
+    dbuf_commit(&db, 32);
+
+    size_t len;
+    ptr = dbuf_get_read_ptr(&db, &len);
+    assert(ptr && len == 32 && ptr[0] == 0xAB);
+    dbuf_consume(&db);
+    assert(!dbuf_is_data_ready(&db));
+
+    printf("  [PASS] test_basic_ping_pong\n");
+    return 0;
+}
+
+static int test_is_write_ready(void)
+{
+    DoubleBuf db;
+    uint8_t mem[2 * PAGE_SZ];
+    assert(dbuf_init(&db, mem, PAGE_SZ));
+
+    assert(dbuf_is_write_ready(&db));   /* 初始空闲 */
+
+    /* 正常写入一帧并消费 */
+    uint8_t *ptr = dbuf_get_write_ptr(&db);
+    memset(ptr, 0xAA, PAGE_SZ);
+    dbuf_commit(&db, PAGE_SZ);
+    assert(dbuf_is_write_ready(&db));   /* 翻转后新写 page 空闲 */
+
+    /* 再写一帧，不消费 → 两个 page 都有数据 */
+    ptr = dbuf_get_write_ptr(&db);
+    memset(ptr, 0xBB, PAGE_SZ);
+    dbuf_commit(&db, PAGE_SZ);
+    assert(!dbuf_is_write_ready(&db));  /* 下一次写入将触发丢弃 */
+
+    /* 消费后仍有旧帧残留在写 page 中，write_ready 仍为 false */
+    dbuf_get_read_ptr(&db, NULL);
+    dbuf_consume(&db);
+    assert(!dbuf_is_write_ready(&db));  /* 写 page 中还残留旧帧 */
+
+    /* get_write_ptr 丢弃旧帧后恢复 */
+    dbuf_get_write_ptr(&db);
+    assert(dbuf_drop_count(&db) == 1U);
+    assert(dbuf_is_write_ready(&db));
+
+    printf("  [PASS] test_is_write_ready\n");
+    return 0;
+}
+
+static int test_drop_on_get_write_ptr(void)
+{
+    DoubleBuf db;
+    uint8_t mem[2 * PAGE_SZ];
+    assert(dbuf_init(&db, mem, PAGE_SZ));
+
+    /* commit 不会触发丢弃 */
+    dbuf_commit(&db, PAGE_SZ);
+    dbuf_commit(&db, PAGE_SZ);
+    assert(dbuf_drop_count(&db) == 0U);
+
+    /* get_write_ptr 发现旧数据 → 触发丢弃 */
+    uint8_t *ptr = dbuf_get_write_ptr(&db);
+    assert(ptr != NULL);
+    assert(dbuf_drop_count(&db) == 1U);
+
+    dbuf_commit(&db, PAGE_SZ);
+    assert(dbuf_drop_count(&db) == 1U);
+
+    printf("  [PASS] test_drop_on_get_write_ptr\n");
+    return 0;
+}
+
+static int test_convenience_api(void)
+{
+    DoubleBuf db;
+    uint8_t mem[2 * PAGE_SZ];
+    assert(dbuf_init(&db, mem, PAGE_SZ));
+
+    const char *msg = "hello double buffer";
+    dbuf_write(&db, msg, strlen(msg) + 1);
+
+    uint8_t buf[64];
+    size_t n = dbuf_read(&db, buf, sizeof(buf));
+    assert(n == strlen(msg) + 1);
+    assert(strcmp((char *)buf, msg) == 0);
+    assert(!dbuf_is_data_ready(&db));
+
+    /* 无数据时 read 返回 0 */
+    n = dbuf_read(&db, buf, sizeof(buf));
+    assert(n == 0U);
+
+    printf("  [PASS] test_convenience_api\n");
+    return 0;
+}
+
+static int test_split_and_flush(void)
+{
+    DoubleBuf db;
+    uint8_t p0[PAGE_SZ], p1[PAGE_SZ];
+    assert(dbuf_init_split(&db, p0, p1, PAGE_SZ));
+    assert(dbuf_capacity(&db) == PAGE_SZ);
+
+    dbuf_commit(&db, 10);
+    assert(dbuf_is_data_ready(&db));
+
+    dbuf_flush(&db);
+    assert(!dbuf_is_data_ready(&db));
+    assert(dbuf_drop_count(&db) == 0U);
+
+    printf("  [PASS] test_split_and_flush\n");
+    return 0;
+}
+
+static int test_alloc_free(void)
+{
+    DoubleBuf db;
+    assert(dbuf_alloc(&db, 128, NULL));
+    assert(dbuf_capacity(&db) == 128);
+
+    dbuf_write(&db, "test", 5);
+    uint8_t buf[16];
+    assert(dbuf_read(&db, buf, sizeof(buf)) == 5);
+
+    dbuf_free(&db, NULL);
+    /* double-free 安全（owned 已置 false） */
+    dbuf_free(&db, NULL);
+
+    /* 非 alloc 对象 free 无操作 */
+    uint8_t mem[2 * PAGE_SZ];
+    assert(dbuf_init(&db, mem, PAGE_SZ));
+    dbuf_free(&db, NULL);  /* owned=false，无操作 */
+    assert(dbuf_capacity(&db) == PAGE_SZ);
+
+    printf("  [PASS] test_alloc_free\n");
+    return 0;
+}
+
+int main(void)
+{
+    printf("DoubleBuf unit tests:\n");
+    test_basic_ping_pong();
+    test_is_write_ready();
+    test_drop_on_get_write_ptr();
+    test_convenience_api();
+    test_split_and_flush();
+    test_alloc_free();
+    printf("All tests passed.\n");
+    return 0;
+}

--- a/samples/host/double_buf/xmake.lua
+++ b/samples/host/double_buf/xmake.lua
@@ -1,0 +1,30 @@
+set_project("om_host_samples")
+set_xmakever("3.0.7")
+add_rules("mode.debug", "mode.release")
+
+--[[
+    @target host_double_buf_test_c
+    @brief 测试双缓冲区的乒乓读写
+    @details 编译并运行测试程序，验证 DoubleBuf 的 Ping-Pong 机制。
+
+    在项目根目录中顺次执行以下命令即可运行例程：
+    xmake f -c -P oh_my_robot/samples/host/double_buf -p windows -a x64 -m debug
+    xmake build -P oh_my_robot/samples/host/double_buf host_double_buf_test_c
+    xmake run -P oh_my_robot/samples/host/double_buf host_double_buf_test_c
+]]
+
+target("host_double_buf_test_c")
+    set_kind("binary")
+    set_languages("c11")
+    set_warnings("all")
+    add_includedirs("../../../lib/include")
+    add_includedirs("../../../lib/data_struct/include")
+    add_files("double_buf_test.c")
+    add_files("../../../lib/data_struct/src/double_buf.c")
+    if is_plat("windows") then
+        set_toolchains("msvc")
+        add_cxflags("/utf-8", {force = true})
+    elseif is_plat("linux") then
+        add_syslinks("pthread")
+    end
+target_end()


### PR DESCRIPTION
## Summary
- 新增 `DoubleBuf` 无锁 SPSC 双缓冲区，支持 Ping-Pong 写/读交替
- 零拷贝路径：`dbuf_get_write_ptr` + `dbuf_commit` / `dbuf_get_read_ptr` + `dbuf_consume`
- 非阻塞 memcpy 便捷接口：`dbuf_write` / `dbuf_read`
- 分离 page 初始化（`dbuf_init_split`，适用于 DMA 分散内存）
- 写就绪检测 + 旧帧自动丢弃（`dbuf_is_write_ready`、`dbuf_drop_count`）
- `dbuf_flush` / `dbuf_alloc` / `dbuf_free` 完整生命周期管理
- 6 个 host 端单元测试全部通过

## Test plan
- [x] `samples/host/double_buf/` 非阻塞接口测试（6/6 通过）
- [ ] MCU 端 DMA 零拷贝路径（待硬件测试）