### PR TITLE
fix(p1010b): backfill zero rx timestamp with monotonic clock

### DIFF
--- a/lib/drivers/src/motor/vendors/direct_drive/P1010B.c
+++ b/lib/drivers/src/motor/vendors/direct_drive/P1010B.c
@@ -689,6 +689,10 @@ static void p1010b_internal_rx_callback(Device *device, void *param, CanFilterHa
         memcpy(frame.payload, payload, sizeof(frame.payload));
         frame.dataLength = (uint8_t)rx_message.dsc.dataLen;
         frame.timestampMs = rx_message.dsc.timeStamp;
+        if (frame.timestampMs == 0U)
+        {
+            frame.timestampMs = osal_time_now_monotonic();
+        }
 
         motor_id = (uint8_t)(frame.canId & P1010B_REPLY_ID_LOW_MASK);
         if (!p1010b_internal_is_valid_motor_id(motor_id))


### PR DESCRIPTION
## 变更范围
- 仅修改 `lib/drivers/src/motor/vendors/direct_drive/P1010B.c`
- 在 RX 回调里，当底层 `rx_message.dsc.timeStamp` 为 `0` 时，回退为 `osal_time_now_monotonic()`

## 修改目的
- 修复 `P1010B` 反馈路径中时间戳可能为 `0` 的情况
- 避免上层基于反馈时间戳的新鲜度/在线判据被错误打穿

## 风险点
- 仅影响 `timeStamp == 0` 的接收帧
- 对已有非零时间戳路径无行为变化

## 验证结果
- 已在应用仓联编环境下完成 `xmake build`
- 该修复不包含任何总线级调试计数或临时诊断接口

## 框架依赖变化
- 无新增对外 API
- 无数据结构变化