### PR TITLE
feat(async): workqueue 工作队列模块实现 (#37)

### DIFF
--- a/lib/async/docs/workqueue.md
+++ b/lib/async/docs/workqueue.md
@@ -1,0 +1,87 @@
+# Workqueue 设计文档
+
+## 概述
+
+Workqueue（工作队列）是一个**中断安全的延迟工作调度器**，用于将耗时操作从 ISR/高优先级线程上下文卸载到专用的 worker 线程中执行。
+
+### 设计目标
+
+| 目标        | 说明                                                              |
+| --------- | --------------------------------------------------------------- |
+| **中断安全**  | ISR 可直接调用 `workqueue_enqueue` / `workqueue_cancel`，无需额外的锁或上下文判断 |
+| **去重**    | 同一 Work 重复入队返回 BUSY，防止意外堆积                                      |
+| **可取消**   | 支持从 pending 队列中 O(1) 取消未执行的工作项                                  |
+| **简单**    | 仅关中断保护，无 CAS 自旋、互斥量、优先级继承等复杂机制                                  |
+| **极小临界区** | irq\_lock 内仅做指针赋值操作，关中断时间可忽略                                    |
+
+## 并发模型
+
+### 核心原理：开关中断 + 分层同步策略
+
+单核 + RTOS 下，所有并发竞争源自 ISR/线程 打断线程。
+
+- **irq\_lock 内**：临界区提供互斥 + 编译器屏障，flags 使用普通 volatile 读写，无需原子操作
+- **irq\_lock 外**：使用原子操作建立 happens-before（enqueue CAS、worker STORE\_REL、work\_is\_busy LOAD\_ACQ）
+
+### 保护范围
+
+| 共享状态                      | 保护方式                                                                      |
+| ------------------------- | ------------------------------------------------------------------------- |
+| `Workqueue.pending` 链表    | `osal_irq_lock`                                                           |
+| `Work.flags`（irq\_lock 内） | 临界区互斥，普通 volatile 读写                                                      |
+| `Work.flags`（irq\_lock 外） | `CAS_RLX`（enqueue 去重）、`STORE_REL`（worker 发布完成）、`LOAD_ACQ`（work\_is\_busy） |
+| `Workqueue.state`         | `CAS_AR`（生命周期切换）、`LOAD_ACQ`（状态检查）                                         |
+
+## 标志位状态机
+
+```
+Work.flags:
+                         ┌───────────────────────┐
+                         │                       │
+                         ▼                       │
+┌──────┐  enqueue   ┌─────────┐   worker    ┌─────────┐   func结束   ┌──────┐
+│ IDLE │ ────────►  │ PENDING │ ──────────► │ RUNNING │ ──────────►  │ IDLE │
+└──────┘   CAS      └─────────┘   flags=    └─────────┘   STORE_REL  └──────┘
+   ▲                    │        RUNNING                     ▲
+   │                    │ cancel                             │
+   │                    ▼                                    │
+   │              ┌──────────────┐                           │
+   │              │ PENDING|     │                           │
+   │              │ CANCELLED    │─── worker 检测到 ──────────┘
+   │              └──────┬───────┘    跳过 func, STORE_REL IDLE
+   │                     │
+   └── cancel list_del ──┘
+
+Workqueue.state:
+  ┌────────┐  init    ┌──────┐  start    ┌─────────┐  stop     ┌──────────┐
+  │ UNINIT │ ──────►  │ IDLE │ ────────► │ RUNNING │ ────────► │ STOPPING │
+  └────────┘          └──────┘   CAS     └─────────┘   CAS      └─────┬────┘
+       ▲                 ▲                                              │
+       │                 │              drain完成                       │
+       │                 └──────────────────────────────────────────────┘
+       └── deinit
+```
+
+## API 参考
+
+| API                           | ISR 安全   | 说明                   |
+| ----------------------------- | -------- | -------------------- |
+| `workqueue_init(wq, cfg)`     | -        | 初始化，分配信号量/completion |
+| `workqueue_start(wq)`         | -        | 创建 worker 线程         |
+| `workqueue_stop(wq)`          | -        | 排空 + 等待 worker 退出    |
+| `workqueue_enqueue(wq, work)` | ✓        | 入队，去重（重复返回 BUSY）     |
+| `workqueue_cancel(work)`      | ✓        | 取消 pending 工作项       |
+| `workqueue_flush(wq)`         | ✗ (阻塞调用) | 排空所有 pending 工作并等待   |
+| `workqueue_is_empty(wq)`      | ✓        | 查询队列是否为空             |
+| `work_is_busy(work)`          | ✓        | 查询工作项是否忙碌            |
+
+## 演进方向：多 Worker 支持
+
+当前设计为单 Worker 模型（一个 Workqueue 内嵌一个 Worker 线程）。未来可扩展为多 Worker，演进路径：
+
+1. 在 `WorkqueueConfig` 中增加 `worker_count` 字段
+2. Workqueue 内部维护一个 worker 线程数组，所有 worker 共享同一个 pending list + semaphore
+3. 保持现有 API 不变，cancel/flush 语义通过多 worker 协调自然扩展
+
+**暂不实现的原因**：单核 Cortex-M 上多 worker 无并行收益，仅增加栈内存消耗和上下文切换开销。待多核场景或明确并发瓶颈时再引入。
+

--- a/lib/async/include/async/workqueue.h
+++ b/lib/async/include/async/workqueue.h
@@ -1,0 +1,341 @@
+/**
+ * @file    workqueue.h
+ * @brief   工作队列：关中断保护的双向链表工作队列（参考 Linux cmwq / Zephyr work_q）
+ * @details
+ *
+ *
+ * ## 并发模型：开关中断 (irq_lock)
+ *
+ * 单核 MCU 上，所有并发竞争源自 ISR/线程 打断线程。本模块统一使用关中断
+ * 临界区保护 pending 链表和 Work.flags 的读写：
+ *
+ * | 调用上下文   | 关中断方式                  | 效果                          |
+ * |-------------|---------------------------|------------------------------|
+ * | 线程上下文   | osal_irq_lock_task()      | taskENTER_CRITICAL（禁中断 + 禁抢占）|
+ * | ISR 上下文  | osal_irq_lock_from_isr()  | 保存并屏蔽中断掩码               |
+ *
+ * irq_lock 临界区内代码极为简短（几个指针赋值），关中断时间可忽略。
+ * 因为关中断自动禁止了抢占，临界区内无需 CAS 自旋、互斥量或额外内存屏障。
+ *
+ * ## 数据结构：侵入式双向链表
+ *
+ * pending 队列基于 `ListHead` 双向循环链表，Work.node 嵌入在 Work 结构体中：
+ *
+ * ```
+ *   Workqueue.pending (哨兵)
+ *        ↓
+ *   [哨兵] ⇄ [Work A] ⇄ [Work B] ⇄ [Work C] ⇄ [哨兵]
+ * ```
+ *
+ * 双向链表支持两项关键操作：
+ * - **O(1) 队头出队**: worker 通过 list_first_entry 获取下一个工作项
+ * - **O(1) 任意位置删除**: cancel 通过 list_node_is_linked + list_del_init 从队列中间移除
+ *
+ * ## Worker Ownership 协议
+ *
+ * Enqueue、Worker、Cancel 三方通过 irq_lock + flags 标志位协调对 Work 的"所有权"：
+ *
+ * ```
+ * enqueue:  [CAS: IDLE→PENDING]  →  [irq_lock: list_add_tail]  →  [sem_post]
+ * worker:   [sem_wait]  →  [irq_lock: list_del + flags=PENDING→RUNNING]  →  [执行 func]
+ * cancel:   [irq_lock: 检查 flags + 设置 CANCELLED + 可能 list_del]
+ * ```
+ *
+ * **关键不变量**: list_del_init 和 flags 状态转换必须在同一 irq_lock 临界区内完成。
+ * 这确保 cancel 看到 PENDING 时节点必定在链表中，看到 RUNNING 时 worker 已认领。
+ *
+ * ## 生命周期状态机
+ *
+ * ```
+ *   UNINIT ── init ──→ IDLE ──start──→ RUNNING ──stop──→ STOPPING ── drain ──→ IDLE
+ *                     ↑                                                    │
+ *                     └────────────────────────────────────────────────────┘
+ *                                        (可循环)
+ *                                     deinit → UNINIT
+ * ```
+ */
+#ifndef ASYNC_WORKQUEUE_H
+#define ASYNC_WORKQUEUE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "data_struct/corelist.h"
+#include "core/om_def.h"
+#include "osal/osal_core.h"
+#include "osal/osal_sem.h"
+#include "osal/osal_thread.h"
+#include "atomic/atomic_simple.h"
+
+/* --------------------------------------------------------------------------
+ * Work 标志位（内部使用）
+ *
+ * 状态迁移规则：
+ *   IDLE ──[enqueue CAS]──→ PENDING ──[worker]──→ RUNNING ──[func 结束]──→ IDLE
+ *   PENDING ──[cancel]──→ PENDING | CANCELLED ──[cancel list_del]──→ IDLE
+ *   PENDING ──[cancel]──→ PENDING | CANCELLED ──[worker 检测到, 跳过]──→ RUNNING → IDLE
+ * -------------------------------------------------------------------------- */
+
+#define WORK_FLAG_IDLE      ((uint32_t)0x00U) /**< 空闲，可被入队 */
+#define WORK_FLAG_PENDING   ((uint32_t)0x01U) /**< 在 pending 队列中等待 */
+#define WORK_FLAG_CANCELLED ((uint32_t)0x02U) /**< 取消请求已发出 */
+#define WORK_FLAG_RUNNING   ((uint32_t)0x04U) /**< worker 正在执行 */
+
+/* --------------------------------------------------------------------------
+ * Workqueue 生命周期状态
+ * -------------------------------------------------------------------------- */
+
+#define WORKQUEUE_STATE_UNINIT   0 /**< 从未初始化或已销毁 */
+#define WORKQUEUE_STATE_IDLE     1 /**< 已初始化但 worker 未运行 */
+#define WORKQUEUE_STATE_RUNNING  2 /**< 接受并执行工作 */
+#define WORKQUEUE_STATE_STOPPING 3 /**< 正在排空，拒绝新工作 */
+
+/* --------------------------------------------------------------------------
+ * 类型定义
+ * -------------------------------------------------------------------------- */
+
+/** Work 前置声明，用于 WorkFunc 签名 */
+typedef struct Work Work;
+
+/**
+ * @brief 工作函数签名
+ *
+ * 参考 Linux kernel 的 work_func_t，对应于 FreeRTOS 的 TimerCallbackFunction_t。
+ * 当 work 被调度执行时，worker 线程调用此函数。
+ *
+ * @param work  指向正在执行的 Work。使用 container_of() 获取嵌入结构体。
+ *
+ * 示例：
+ *   struct my_device {
+ *       Work ws;
+ *       int state;
+ *   };
+ *
+ *   void my_handler(Work *w) {
+ *       struct my_device *dev = container_of(w, struct my_device, ws);
+ *       dev->state = 1;
+ *   }
+ */
+typedef void (*WorkFunc)(Work *work);
+
+/**
+ * @brief 工作项（嵌入调用者结构体使用）
+ *
+ *
+ * 字段说明：
+ * - node:  侵入式双向链表节点，挂在 Workqueue.pending 队列中
+ * - func:  工作处理函数，worker 线程执行时调用
+ * - data:  用户上下文指针，可在 handler 中通过 work->data 访问
+ * - flags: 状态标志位（WORK_FLAG_*），在 irq_lock 内管理
+ */
+struct Work {
+    ListHead      node;  /**< 侵入式链表节点，挂在 pending 队列 */
+    WorkFunc      func;  /**< 工作处理函数 */
+    void         *data;  /**< 用户上下文 */
+    OmAtomicUint  flags; /**< 状态标志位 (WORK_FLAG_*) */
+};
+
+/**
+ * @brief 工作队列配置参数
+ *
+ * 传递给 workqueue_init()，设置 worker 线程属性。
+ */
+typedef struct WorkqueueConfig {
+    const char *name;        /**< 调试名称（用作线程名） */
+    uint32_t    stack_depth; /**< worker 线程栈大小（字节） */
+    uint32_t    priority;    /**< worker 线程优先级（FreeRTOS 优先级值） */
+} WorkqueueConfig;
+
+/**
+ * @brief 工作队列实例
+ *
+ * 用法：
+ *   Workqueue wq;
+ *   workqueue_init(&wq, &cfg);
+ */
+struct Workqueue {
+    ListHead     pending;      /**< pending 工作项双向链表哨兵 */
+    OsalSem     *sem;          /**< 工作到达信号量（计数型，最大1） */
+    OsalThread  *thread;       /**< worker 线程句柄 */
+    Completion   done;         /**< worker 退出同步原语 */
+    OmAtomicInt  state;        /**< 生命周期状态 (WORKQUEUE_STATE_*) */
+    uint32_t     stack_depth;  /**< worker 线程栈大小（字节） */
+    uint32_t     priority;     /**< worker 线程优先级 */
+    const char  *name;         /**< 调试名称 */
+};
+
+/* --------------------------------------------------------------------------
+ * API
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @brief 初始化工作队列实例
+ *
+ * 分配信号量和 completion 资源。初始化后状态为 IDLE，
+ * 需要调用 workqueue_start() 启动 worker 线程。
+ *
+ * @param wq   Workqueue 实例指针。
+ * @param cfg  配置参数（名称、栈大小、优先级）；不可为 NULL。
+ * @return     OM_OK 成功，否则返回错误码。
+ *
+ * @pre  wq 指向有效的 Workqueue 实例。
+ * @post wq 处于 WORKQUEUE_STATE_IDLE 状态。
+ */
+OmRet workqueue_init(Workqueue *wq, const WorkqueueConfig *cfg);
+
+/**
+ * @brief 销毁工作队列，释放所有资源
+ *
+ * @param wq  工作队列实例。
+ * @return    OM_OK 成功，否则返回错误码。
+ *
+ * @pre  workqueue_stop() 必须已先调用，状态必须为 IDLE。
+ * @post wq 处于 WORKQUEUE_STATE_UNINIT 状态。
+ */
+OmRet workqueue_deinit(Workqueue *wq);
+
+/**
+ * @brief 启动 worker 线程，开始接受并执行工作
+ *
+ * 创建 FreeRTOS 任务作为 worker 线程。worker 线程从 pending 队列中
+ * 取出 Work 并调用其 func 回调。
+ *
+ * @param wq  已初始化的工作队列。
+ * @return    OM_OK 成功，否则返回错误码。
+ *
+ * @pre  wq 必须处于 IDLE 状态。
+ * @post wq 处于 RUNNING 状态，worker 线程运行中。
+ */
+OmRet workqueue_start(Workqueue *wq);
+
+/**
+ * @brief 停止接收新工作，排空 pending 队列，等待 worker 线程退出
+ *
+ * 阻塞直到 worker 线程完全退出且所有 pending work 已被执行或清理。
+ * 停止后可以再次 start 重新启动。
+ *
+ * @param wq  正在运行的工作队列。
+ * @return    OM_OK 成功，否则返回错误码。
+ *
+ * @pre  wq 必须处于 RUNNING 状态。
+ * @post wq 处于 IDLE 状态，worker 线程已退出。
+ */
+OmRet workqueue_stop(Workqueue *wq);
+
+/**
+ * @brief 将工作项入队，等待异步执行
+ *
+ * 线程安全和 ISR 安全。
+ *
+ * 去重语义: 如果 work 已在 pending 队列中或正在执行，返回 OM_ERROR_BUSY，
+ * 调用为无操作。这与 Linux cmwq 的 `queue_work()` 行为一致
+ * （WQ_UNBOUND 模式下通过 WORK_STRUCT_PENDING_BIT 实现）。
+ *
+ * **调度保证**: work 最终会在 worker 线程上下文中被恰好执行一次（除非被 cancel）。
+ *
+ * @param wq    目标工作队列。
+ * @param work  要入队的工作项。必须已通过 work_init() 初始化。
+ * @return      OM_OK 成功入队；
+ *              OM_ERROR 工作队列未在运行；
+ *              OM_ERROR_BUSY 工作项已在队列中或正在执行；
+ *              OM_ERROR_PARAM 参数为 NULL。
+ */
+OmRet workqueue_enqueue(Workqueue *wq, Work *work);
+
+/**
+ * @brief 取消一个尚未执行的工作项
+ *
+ * 线程安全和 ISR 安全。
+ *
+ * 如果 work 正处于 pending 状态（在队列中等待），将其从 pending 队列中移除
+ * 并恢复为 IDLE 状态，可以重新入队。
+ *
+ * 如果 work 正在 worker 线程上执行，取消无法进行，返回 OM_ERROR_BUSY。
+ *
+ * **设计要点**: 调用者无需知道 work 在哪个 workqueue 上——Work 自身持有
+ * 所有必要状态（flags + list node），cancel 通过 irq_lock 原子地检查
+ * flags 并操作链表。
+ *
+ * @param work  要取消的工作项。
+ * @return      OM_OK 成功取消；
+ *              OM_ERROR_BUSY 工作项正在执行无法取消；
+ *              OM_ERROR 工作项不在 pending 状态；
+ *              OM_ERROR_PARAM 参数为 NULL。
+ */
+OmRet workqueue_cancel(Work *work);
+
+/**
+ * @brief 排空所有 pending 工作项并等待完成
+ *
+ * 同步等待——返回时，所有当前 pending 的工作项已执行完毕（或被取消）。
+ * 工作队列必须处于 RUNNING 状态。
+ *
+ * 实现通过两次 sem_post/sem_wait 握手确保 worker 已完成至少一次完整的
+ * 排空循环。
+ *
+ * @param wq  正在运行的工作队列。
+ * @return    OM_OK 成功，OM_ERROR 工作队列未在运行，OM_ERROR_PARAM 参数为 NULL。
+ */
+OmRet workqueue_flush(Workqueue *wq);
+
+/**
+ * @brief 查询工作队列当前生命周期状态
+ *
+ * @param wq  工作队列实例。
+ * @return    WORKQUEUE_STATE_UNINIT / IDLE / RUNNING / STOPPING。
+ */
+int workqueue_get_state(const Workqueue *wq);
+
+/**
+ * @brief 查询 pending 队列是否为空
+ *
+ * 线程安全和 ISR 安全。
+ *
+ * @param wq  工作队列实例。
+ * @return    true 无 pending 工作项。
+ */
+bool workqueue_is_empty(const Workqueue *wq);
+
+/* --------------------------------------------------------------------------
+ * 内联辅助函数
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @brief 初始化 Work 结构体（首次使用前必须调用）
+ *
+ * 设置链表节点为哨兵态（自循环）、绑定处理函数和用户上下文、
+ * 将 flags 重置为 IDLE。
+ *
+ * @param work  预分配的工作项。
+ * @param func  工作执行时调用的处理函数。
+ * @param data  用户上下文，可通过 work->data 访问。
+ */
+static inline void work_init(Work *work, WorkFunc func, void *data)
+{
+    INIT_LIST_HEAD(&work->node);
+    work->func = func;
+    work->data = data;
+    OM_STORE_RLX(&work->flags, WORK_FLAG_IDLE);
+}
+
+/**
+ * @brief 查询工作项是否处于忙碌状态（pending 或 running）
+ *
+ * @param work  工作项。
+ * @return      true 工作项正在队列中或正在执行。
+ */
+static inline bool work_is_busy(const Work *work)
+{
+    uint32_t f = OM_LOAD_ACQ(&work->flags);
+    return (f & (WORK_FLAG_PENDING | WORK_FLAG_RUNNING)) != 0U;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASYNC_WORKQUEUE_H */

--- a/lib/async/src/workqueue.c
+++ b/lib/async/src/workqueue.c
@@ -1,0 +1,509 @@
+/**
+ * @file    workqueue.c
+ * @brief   工作队列实现 —— 关中断 + 双向链表
+ *
+ * @details
+ *
+ * ## 并发模型：开关中断 (irq_lock)
+ *
+ * 单核 Cortex-M + FreeRTOS 下，所有并发源自 ISR 打断线程。本实现使用
+ * 统一的关中断临界区（irq_lock）保护 pending 链表和 Work.flags：
+ *
+ *   - **线程上下文**: osal_irq_lock_task() → taskENTER_CRITICAL()
+ *     （禁用中断 + 禁止任务切换）
+ *   - **ISR 上下文**: osal_irq_lock_from_isr() → 保存并屏蔽中断掩码
+ *
+ * irq_lock 临界区内代码极为简短（几个指针赋值 + 位操作），关中断时间可忽略。
+ * 因为关中断自动禁止了抢占，临界区内**不需要** CAS 自旋、互斥量或额外内存屏障。
+ *
+ * ## 数据结构
+ *
+ * ```
+ *   Workqueue.pending → ListHead (双向循环链表哨兵)
+ *   Work.node          → ListHead (嵌入 Work 的节点)
+ *   Work.flags         → OmAtomicUint (PENDING | CANCELLED | RUNNING 状态位)
+ * ```
+ *
+ * pending 队列采用双向链表，支持：
+ *   - **O(1) 队头出队**: worker 通过 list_first_entry + list_del_init 认领工作
+ *   - **O(1) 任意位置删除**: cancel 通过 list_node_is_linked + list_del_init 从队列中间移除
+ *
+ * ## Worker Claim 协议（核心并发合同）
+ *
+ * Enqueue、Worker、Cancel 三方通过 irq_lock + flags 原子操作协调对 Work 的"所有权"：
+ *
+ * ```
+ * enqueue:  [CAS: IDLE→PENDING]  →  [irq_lock: list_add_tail]  →  [sem_post]
+ * worker:   [sem_wait]  →  [irq_lock: list_del_init + flags=PENDING→RUNNING]  →  [执行 func]
+ * cancel:   [irq_lock: 检查 flags + 设置 CANCELLED + 可能 list_del_init]
+ * ```
+ *
+ * **关键不变量**: list_del_init 和 flags 状态转换必须在同一 irq_lock 临界区内完成。
+ * 这确保 cancel 看到 PENDING 时节点必定在链表中，看到 RUNNING 时 worker 已认领。
+ *
+ * ## 内存序策略
+ *
+ * - **irq_lock 内**: 临界区提供互斥 + 编译器屏障，flags 使用普通 volatile 读写
+ * - **irq_lock 外**: 使用原子操作（enqueue CAS、worker STORE_REL、work_is_busy LOAD_ACQ）
+ */
+
+#include "async/workqueue.h"
+#include "sync/completion.h"
+
+#include <stddef.h>
+
+/** 信号量最大计数：1（二值信号量，用于唤醒通知） */
+#define WQ_SEM_MAX_COUNT ((uint32_t)1U)
+
+/* ===================================================================
+ * Worker 线程
+ *
+ * worker 线程是工作队列的核心消费者，运行以下循环：
+ *   1. sem_wait 等待工作到达信号
+ *   2. 在 irq_lock 内从 pending 链表头部取出一个 Work
+ *   3. 在 irq_lock 内检查 flags 并认领 Work 的所有权
+ *   4. 在 irq_lock 外执行 Work.func 回调
+ *   5. 重复直到链表为空，检查 STOPPING 退出条件
+ *
+ * 对应 Linux kernel process_one_work() 的简化版。
+ * =================================================================== */
+
+/**
+ * @brief Worker 线程入口函数
+ *
+ * @param arg  指向 Workqueue 实例的指针。
+ */
+static void workqueue_worker_entry(void *arg)
+{
+    Workqueue *wq = (Workqueue *)arg;
+
+    for (;;) {
+        /** 1. 等待工作到达或停止信号 */
+        osal_sem_wait(wq->sem, OSAL_WAIT_FOREVER);
+
+        /** 2. 循环排空 pending 队列 */
+        for (;;) {
+            Work  *w        = NULL;
+            bool   cancelled = false;
+
+            /** 2a. 关中断：从链表取出下一个工作项并认领 */
+            {
+                OsalIrqIsrState k;
+                osal_irq_lock(&k);
+
+                if (!list_empty(&wq->pending)) {
+                    w = list_first_entry(&wq->pending, Work, node);
+
+                    /** 从 pending 链表移除并毒化节点。 */
+                    list_del_init(&w->node);
+
+                    /** 认领所有权：PENDING → RUNNING。
+                     *
+                     *  irq_lock 内，cancel 不可能并发修改 flags，
+                     *  直接比较即可检测 cancel 是否设置了 CANCELLED。 */
+                    if (w->flags == WORK_FLAG_PENDING) {
+                        w->flags = WORK_FLAG_RUNNING;
+                        cancelled = false;
+                    } else {
+                        /** flags 已被 cancel 改为 PENDING|CANCELLED。
+                         *  我们已从链表取出（拥有所有权），
+                         *  设置 RUNNING 阻止后续 cancel 竞争。 */
+                        w->flags = WORK_FLAG_RUNNING;
+                        cancelled = true;
+                    }
+                }
+
+                osal_irq_unlock(k);
+            }
+
+            /** 2b. 无更多工作：检查退出条件 */
+            if (!w) {
+                int s = OM_LOAD_ACQ(&wq->state);
+                if (s == WORKQUEUE_STATE_STOPPING) {
+                    /** STOPPING 状态 + 队列已空 → worker 退出 */
+                    completion_done(&wq->done);
+                    osal_thread_exit();
+                }
+                /** 回到 sem_wait 等待新工作 */
+                break;
+            }
+
+            /** 2c. 执行或跳过 */
+            if (cancelled) {
+                /** cancel 已请求取消 → 恢复 IDLE，不执行 func */
+                OM_STORE_REL(&w->flags, WORK_FLAG_IDLE);
+            } else {
+                /** 正常执行工作函数 */
+                w->func(w);
+                /** 执行完毕，恢复 IDLE，允许再次入队 */
+                OM_STORE_REL(&w->flags, WORK_FLAG_IDLE);
+            }
+        }
+    }
+}
+
+/* ===================================================================
+ * 生命周期管理：init / deinit
+ * =================================================================== */
+
+/**
+ * @brief 初始化工作队列实例
+ *
+ * 初始化 pending 链表哨兵，创建信号量和 completion。
+ * 初始化后状态为 IDLE，需调用 workqueue_start() 启动 worker 线程。
+ *
+ * @param wq   Workqueue 实例指针。
+ * @param cfg  配置参数（名称、栈大小、优先级）；不可为 NULL。
+ * @return     OM_OK 成功，OM_ERROR 资源分配失败，OM_ERROR_PARAM 参数为 NULL。
+ */
+OmRet workqueue_init(Workqueue *wq, const WorkqueueConfig *cfg)
+{
+    if (!wq || !cfg) return OM_ERROR_PARAM;
+
+    /** 初始化 pending 链表为空的哨兵态（自循环） */
+    INIT_LIST_HEAD(&wq->pending);
+    wq->thread = NULL;
+
+    /** 创建计数型信号量（最大计数 1，初始计数 0） */
+    OsalStatus st = osal_sem_create(&wq->sem, WQ_SEM_MAX_COUNT, 0U);
+    if (st != OSAL_OK) return OM_ERROR;
+
+    /** 初始化 worker 退出同步原语 */
+    OmRet rc = completion_init(&wq->done);
+    if (rc != OM_OK) {
+        osal_sem_delete(wq->sem);
+        wq->sem = NULL;
+        return rc;
+    }
+
+    /** 设置状态为 IDLE */
+    OM_STORE_RLX(&wq->state, (int)WORKQUEUE_STATE_IDLE);
+    wq->name        = cfg->name ? cfg->name : "wq";
+    wq->stack_depth = cfg->stack_depth;
+    wq->priority    = cfg->priority;
+
+    return OM_OK;
+}
+
+/**
+ * @brief 销毁工作队列，释放所有资源
+ *
+ * @param wq  工作队列实例。
+ * @return    OM_OK 成功，OM_ERROR 状态非法（未先 stop），OM_ERROR_PARAM 参数为 NULL。
+ *
+ * @pre  workqueue_stop() 必须已先调用。
+ * @post 信号量已删除，completion 已销毁，状态为 UNINIT。
+ */
+OmRet workqueue_deinit(Workqueue *wq)
+{
+    if (!wq) return OM_ERROR_PARAM;
+
+    /** 必须已 stop */
+    int s = OM_LOAD_RLX(&wq->state);
+    if (s != WORKQUEUE_STATE_IDLE) return OM_ERROR;
+
+    if (wq->sem) {
+        osal_sem_delete(wq->sem);
+        wq->sem = NULL;
+    }
+
+    completion_deinit(&wq->done);
+
+    OM_STORE_RLX(&wq->state, (int)WORKQUEUE_STATE_UNINIT);
+    wq->name = NULL;
+    return OM_OK;
+}
+
+/* ===================================================================
+ * 生命周期管理：start / stop
+ * =================================================================== */
+
+/**
+ * @brief 启动 worker 线程
+ *
+ * 通过 CAS 将状态从 IDLE 切换到 RUNNING，然后创建 FreeRTOS 任务
+ * 作为 worker 线程。如果线程创建失败，状态回退到 IDLE。
+ *
+ * @param wq  已初始化的工作队列。
+ * @return    OM_OK 成功，OM_ERROR 状态非法或线程创建失败，OM_ERROR_PARAM 参数为 NULL。
+ */
+OmRet workqueue_start(Workqueue *wq)
+{
+    if (!wq) return OM_ERROR_PARAM;
+    if (!wq->sem) return OM_ERROR; /** 未初始化或已销毁 */
+
+    /** CAS 原子切换：IDLE → RUNNING */
+    int expected = WORKQUEUE_STATE_IDLE;
+    if (!OM_CAS_AR(&wq->state, &expected, WORKQUEUE_STATE_RUNNING)) {
+        return OM_ERROR; /** 不在 IDLE 状态 */
+    }
+
+    /** 排空上一次循环可能残留的信号量计数 */
+    while (osal_sem_wait(wq->sem, 0U) == OSAL_OK) {}
+
+    /** 重置 completion，准备新 worker 周期 */
+    completion_init(&wq->done);
+
+    /** 配置并创建 worker 线程 */
+    OsalThreadAttr attr = {0};
+    attr.name      = wq->name;
+    attr.stackSize = wq->stack_depth;
+    attr.priority  = wq->priority;
+
+    OsalStatus st = osal_thread_create(&wq->thread, &attr,
+                                       workqueue_worker_entry, wq);
+    if (st != OSAL_OK) {
+        /** 线程创建失败，状态回退 */
+        OM_STORE_RLX(&wq->state, (int)WORKQUEUE_STATE_IDLE);
+        return OM_ERROR;
+    }
+
+    return OM_OK;
+}
+
+/**
+ * @brief 停止 worker 线程
+ *
+ * 状态从 RUNNING 切换到 STOPPING，唤醒 worker 线程，等待其排空
+ * pending 队列并退出。worker 退出后进行防御性清理（理论上队列应为空）。
+ *
+ * @param wq  正在运行的工作队列。
+ * @return    OM_OK 成功，OM_ERROR 状态非法（未在运行），OM_ERROR_PARAM 参数为 NULL。
+ */
+OmRet workqueue_stop(Workqueue *wq)
+{
+    if (!wq) return OM_ERROR_PARAM;
+
+    /** CAS 原子切换：RUNNING → STOPPING */
+    int expected = WORKQUEUE_STATE_RUNNING;
+    if (!OM_CAS_AR(&wq->state, &expected, WORKQUEUE_STATE_STOPPING)) {
+        /** 已停止或未在运行 */
+        return OM_ERROR;
+    }
+
+    /** 唤醒 worker 线程，使其开始排空 */
+    osal_sem_post(wq->sem);
+
+    /** 等待 worker 线程退出信号 */
+    completion_wait(&wq->done, OSAL_WAIT_FOREVER);
+    wq->thread = NULL;
+
+    /** 防御性排空：清理可能在 worker 退出与 stop 返回之间入队的工作项。
+     *
+     *  STOPPING 状态下 enqueue 会被拒绝（见 workqueue_enqueue 的状态检查），
+     *  理论上队列应为空，但安全起见，尝试清理所有残留工作项。 */
+    {
+        Work            *w, *tmp;
+        OsalIrqIsrState  k;
+        osal_irq_lock(&k);
+        list_for_each_entry_safe(w, tmp, &wq->pending, node)
+        {
+            list_del_init(&w->node);
+            w->flags = WORK_FLAG_IDLE;
+        }
+        osal_irq_unlock(k);
+    }
+
+    /** 状态切换：STOPPING → IDLE */
+    OM_STORE_RLX(&wq->state, (int)WORKQUEUE_STATE_IDLE);
+
+    return OM_OK;
+}
+
+/* ===================================================================
+ * 入队操作（Enqueue）
+ *
+ * enqueue 分两个阶段：
+ *   1. irq_lock 外 CAS(IDLE→PENDING)：原子去重
+ *   2. irq_lock 内 list_add_tail：保护链表插入的原子性
+ *
+ * CAS 在锁外的设计理由：CAS 竞争方（worker 的 flags 修改）在
+ * irq_lock 内执行，关中断。单核上两个线程级 enqueue 冲突由 CAS 自身解决。
+ * 锁外 CAS 避免了 sem_post 调用时持有 irq_lock（sem_post 可能触发任务切换）。
+ * =================================================================== */
+
+/**
+ * @brief 将工作项入队
+ *
+ * 线程安全和 ISR 安全。
+ *
+ * @param wq    目标工作队列。
+ * @param work  要入队的工作项。
+ * @return      OM_OK 成功入队；
+ *              OM_ERROR 工作队列未在运行；
+ *              OM_ERROR_BUSY 工作项已 PENDING 或 RUNNING；
+ *              OM_ERROR_PARAM 参数为 NULL。
+ */
+OmRet workqueue_enqueue(Workqueue *wq, Work *work)
+{
+    if (!wq || !work) return OM_ERROR_PARAM;
+
+    /** 拒绝：工作队列未在运行 */
+    if (OM_LOAD_ACQ(&wq->state) != WORKQUEUE_STATE_RUNNING) {
+        return OM_ERROR;
+    }
+
+    /** 去重：原子 CAS 从 IDLE 切换到 PENDING。
+     *
+     *  如果 work 当前是 PENDING 或 RUNNING，CAS 失败 → 返回 BUSY
+     *  (等同于 Linux cmwq 的 WORK_STRUCT_PENDING_BIT 去重机制)。 */
+    {
+        uint32_t expected = WORK_FLAG_IDLE;
+        if (!OM_CAS_RLX(&work->flags, &expected, WORK_FLAG_PENDING)) {
+            return OM_ERROR_BUSY; /** 已在队列中或正在执行 */
+        }
+    }
+
+    /** 关中断：将 work 插入 pending 链表尾部（FIFO 顺序） */
+    {
+        OsalIrqIsrState key;
+        osal_irq_lock(&key);
+        list_add_tail(&work->node, &wq->pending);
+        osal_irq_unlock(key);
+    }
+
+    /** 唤醒 worker 线程 */
+    osal_sem_post_auto(wq->sem);
+
+    return OM_OK;
+}
+
+/* ===================================================================
+ * 取消操作
+ *
+ * cancel 所有操作（flags 检查、CANCELLED 标记、链表删除）均在 irq_lock
+ * 临界区内完成。irq_lock 禁用中断和抢占，flags 和链表操作的原子性
+ * 由临界区本身保证，使用普通 volatile 读写即可。
+ * =================================================================== */
+
+/**
+ * @brief 取消一个 pending 工作项
+ *
+ * 线程安全和 ISR 安全。不从特定 workqueue 上取消，而是通过 Work 自身的
+ * flags 和 list node 操作。这意味着调用者无需知道 work 在哪个队列上。
+ *
+ * @param work  要取消的工作项。
+ * @return      OM_OK 成功取消（work 恢复 IDLE，可重新入队）；
+ *              OM_ERROR_BUSY work 正在执行，无法取消；
+ *              OM_ERROR work 不在 pending 状态；
+ *              OM_ERROR_PARAM 参数为 NULL。
+ */
+OmRet workqueue_cancel(Work *work)
+{
+    if (!work) return OM_ERROR_PARAM;
+
+    OsalIrqIsrState key;
+
+    /** ---- 所有 flags 检查和修改均在 irq_lock 内进行 ---- */
+    osal_irq_lock(&key);
+
+    uint32_t f = work->flags;
+
+    /** 拒绝：work 正在执行（worker 已认领） */
+    if (f & WORK_FLAG_RUNNING) {
+        osal_irq_unlock(key);
+        return OM_ERROR_BUSY;
+    }
+
+    /** 拒绝：work 不在 pending 状态（可能已执行完毕或从未入队） */
+    if (!(f & WORK_FLAG_PENDING)) {
+        osal_irq_unlock(key);
+        return OM_ERROR;
+    }
+
+    /** 标记取消意图 */
+    work->flags = f | WORK_FLAG_CANCELLED;
+
+    /** 尝试从 pending 链表移除。
+     *
+     *  因为我们持有 irq_lock，worker 不可能在此期间从链表取走该节点。
+     *  因此在 flags 为 PENDING 的前提下，节点必定仍在链表中。
+     *
+     *  list_del_init 将节点 next/prev 设为 NULL，兼具毒化效果。
+     *  后续 work_init() 会重新 INIT_LIST_HEAD 使节点恢复可用。 */
+    if (list_node_is_linked(&work->node)) {
+        list_del_init(&work->node);
+        /** 成功从链表移除 → 清理所有标志位，work 恢复 IDLE */
+        work->flags = WORK_FLAG_IDLE;
+    }
+    /** 如果节点已不在链表中：worker 已在另一个 irq_lock 临界区中
+     *  将其取出。worker 在检查 flags 时会检测到我们设置的 CANCELLED 位，
+     *  并跳过执行。 */
+
+    osal_irq_unlock(key);
+    return OM_OK;
+}
+
+/* ===================================================================
+ * 排空操作（Flush）
+ *
+ * flush 等待当前 pending 队列中所有工作项执行完毕。
+ * 实现原理：通过两次 sem_post/sem_wait 握手确保 worker 已完成至少
+ * 一次完整的排空循环。
+ * =================================================================== */
+
+/**
+ * @brief 排空所有 pending 工作项并同步等待完成
+ *
+ * @param wq  正在运行的工作队列。
+ * @return    OM_OK 成功，OM_ERROR 状态非法，OM_ERROR_PARAM 参数为 NULL。
+ */
+OmRet workqueue_flush(Workqueue *wq)
+{
+    if (!wq) return OM_ERROR_PARAM;
+
+    /** 工作队列必须处于 RUNNING 状态 */
+    if (OM_LOAD_ACQ(&wq->state) != WORKQUEUE_STATE_RUNNING) {
+        return OM_ERROR;
+    }
+
+    /** 发送两次信号量并等待 worker 两次消费。
+     *
+     *  第一次信号量触发 worker 排空当前 pending 队列，
+     *  第二次信号量确认 worker 已完成排空并回到了 sem_wait 等待状态。
+     *
+     *  这种双握手确保 worker 至少完成了一次完整的"取出→执行→回到等待"
+     *  循环，因此入队早于 flush 调用的所有 work 已处理完毕。 */
+    osal_sem_post_auto(wq->sem);
+    osal_sem_wait(wq->sem, OSAL_WAIT_FOREVER);
+
+    osal_sem_post_auto(wq->sem);
+    osal_sem_wait(wq->sem, OSAL_WAIT_FOREVER);
+
+    return OM_OK;
+}
+
+/* ===================================================================
+ * 查询辅助函数
+ * =================================================================== */
+
+/**
+ * @brief 查询工作队列当前生命周期状态
+ *
+ * @param wq  工作队列实例。
+ * @return    WORKQUEUE_STATE_UNINIT / IDLE / RUNNING / STOPPING。
+ */
+int workqueue_get_state(const Workqueue *wq)
+{
+    if (!wq) return WORKQUEUE_STATE_UNINIT;
+    return OM_LOAD_RLX(&wq->state);
+}
+
+/**
+ * @brief 查询 pending 队列是否为空
+ *
+ * 线程安全和 ISR 安全。在 irq_lock 内读取链表状态，确保获取一致快照。
+ *
+ * @param wq  工作队列实例。
+ * @return    true 无 pending 工作项。
+ */
+bool workqueue_is_empty(const Workqueue *wq)
+{
+    if (!wq) return true;
+
+    OsalIrqIsrState key;
+    osal_irq_lock(&key);
+    bool empty = list_empty(&wq->pending);
+    osal_irq_unlock(key);
+    return empty;
+}

--- a/lib/osal/include/osal/osal_core.h
+++ b/lib/osal/include/osal/osal_core.h
@@ -56,6 +56,40 @@ OsalIrqIsrState osal_irq_lock_from_isr(void);
 void osal_irq_unlock_from_isr(OsalIrqIsrState state);
 
 /**
+ * @brief 上下文自动分派：进入关中断临界区
+ *
+ * 自动检测当前上下文（线程或 ISR），选择对应的锁原语。
+ * 线程上下文调用 osal_irq_lock_task()，ISR 上下文调用 osal_irq_lock_from_isr()。
+ *
+ * @param[out] key     ISR 上下文时保存的中断状态，线程上下文时填 0。
+ */
+static inline void osal_irq_lock(OsalIrqIsrState *key)
+{
+    if (osal_is_in_isr()) {
+        *key = osal_irq_lock_from_isr();
+    } else {
+        osal_irq_lock_task();
+        *key = 0U;
+    }
+}
+
+/**
+ * @brief 上下文自动分派：退出关中断临界区
+ *
+ * 与 osal_irq_lock() 配对使用。
+ *
+ * @param key     osal_irq_lock() 保存的中断状态。
+ */
+static inline void osal_irq_unlock(OsalIrqIsrState key)
+{
+    if (osal_is_in_isr()) {
+        osal_irq_unlock_from_isr(key);
+    } else {
+        osal_irq_unlock_task();
+    }
+}
+
+/**
  * @brief OSAL 内存申请
  * @param size 申请字节数
  * @return 成功返回指针，失败返回 NULL

--- a/lib/osal/include/osal/osal_sem.h
+++ b/lib/osal/include/osal/osal_sem.h
@@ -54,6 +54,23 @@ OsalStatus osal_sem_post(OsalSem* sem);
 OsalStatus osal_sem_post_from_isr(OsalSem* sem);
 
 /**
+ * @brief 上下文自动分派：释放信号量
+ *
+ * 自动检测当前上下文（线程或 ISR），选择对应的 post 变体。
+ * 线程上下文调用 osal_sem_post()，ISR 上下文调用 osal_sem_post_from_isr()。
+ *
+ * @param sem  信号量句柄
+ * @return     `OSAL_OK` 成功；失败返 `OSAL_INVALID/OSAL_NO_RESOURCE`
+ */
+static inline OsalStatus osal_sem_post_auto(OsalSem* sem)
+{
+    if (osal_is_in_isr()) {
+        return osal_sem_post_from_isr(sem);
+    }
+    return osal_sem_post(sem);
+}
+
+/**
  * @brief 获取信号量当前计数（线程上下文）
  * @param sem 信号量句
  * @param out_count 输出计数

--- a/samples/async/workqueue/main.c
+++ b/samples/async/workqueue/main.c
@@ -1,0 +1,445 @@
+/**
+ * @file    main.c
+ * @brief   Workqueue 独立测试例程（MCU / FreeRTOS 目标）
+ * @details
+ * 本例程覆盖 Workqueue 的核心合同——生命周期、入队/去重、取消、排空。
+ * 测试结果存储在全局 volatile 结构体中，可通过调试器检查。
+ *
+ * 观测变量：
+ *   - g_result.total   : 累计断言数量
+ *   - g_result.failed  : 失败断言数量
+ *   - g_result.done    : 测试是否已执行完成（1 表示完成）
+ */
+
+#include "async/workqueue.h"
+#include "data_struct/corelist.h"
+#include "osal/osal.h"
+#include "osal/osal_config.h"
+#include "sync/completion.h"
+
+/* --------------------------------------------------------------------------
+ * Workqueue 实例分配
+ *
+ * 结构体定义已暴露在头文件中，可直接声明使用。
+ * -------------------------------------------------------------------------- */
+
+/* --------------------------------------------------------------------------
+ * 测试结果追踪
+ * -------------------------------------------------------------------------- */
+
+typedef struct {
+    volatile uint32_t total;
+    volatile uint32_t failed;
+    volatile uint32_t done;
+} TestResult;
+
+static TestResult g_result;
+
+static void expect(int condition)
+{
+    g_result.total++;
+    if (!condition) g_result.failed++;
+}
+
+/* --------------------------------------------------------------------------
+ * 测试工作项 —— handler 完成时 post semaphore
+ * -------------------------------------------------------------------------- */
+
+typedef struct {
+    Work     w;
+    OsalSem *s;
+    int      ex;
+    int      id;
+} TW;
+
+static void tw_handler(Work *w)
+{
+    TW *t = container_of(w, TW, w);
+    t->ex++;
+    if (t->s) osal_sem_post(t->s);
+}
+
+static void tw_init(TW *t, int id, OsalSem *s)
+{
+    work_init(&t->w, tw_handler, NULL);
+    t->s  = s;
+    t->ex = 0;
+    t->id = id;
+}
+
+static OsalSem *make_sem(void)
+{
+    OsalSem *s = NULL;
+    (void)osal_sem_create(&s, 1u, 0u);
+    return s;
+}
+
+static int wait_sem(OsalSem *s, uint32_t timeout_ms)
+{
+    return osal_sem_wait(s, timeout_ms) == OSAL_OK;
+}
+
+/* --------------------------------------------------------------------------
+ * 测试用例
+ * -------------------------------------------------------------------------- */
+
+/* 测试1：NULL 参数校验 */
+static void t_null_params(void)
+{
+    Workqueue wq = {0};
+    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+
+    expect(workqueue_init(&wq, &cfg) == OM_OK);
+    expect(workqueue_enqueue(NULL, NULL) == OM_ERROR_PARAM);
+    expect(workqueue_enqueue(&wq, NULL) == OM_ERROR_PARAM);
+    expect(workqueue_cancel(NULL) == OM_ERROR_PARAM);
+    expect(workqueue_init(NULL, &cfg) == OM_ERROR_PARAM);
+    expect(workqueue_init(&wq, NULL) == OM_ERROR_PARAM);
+    expect(workqueue_deinit(NULL) == OM_ERROR_PARAM);
+    expect(workqueue_start(NULL) == OM_ERROR_PARAM);
+    expect(workqueue_stop(NULL) == OM_ERROR_PARAM);
+    expect(workqueue_get_state(NULL) == WORKQUEUE_STATE_UNINIT);
+    expect(workqueue_is_empty(NULL) == true);
+    expect(workqueue_deinit(&wq) == OM_OK);
+}
+
+/* 测试2：生命周期状态机 IDLE→RUNNING→STOPPING→IDLE */
+static void t_lifecycle(void)
+{
+    Workqueue wq = {0};
+    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+
+    expect(workqueue_get_state(&wq) == WORKQUEUE_STATE_UNINIT);
+    expect(workqueue_init(&wq, &cfg) == OM_OK);
+    expect(workqueue_get_state(&wq) == WORKQUEUE_STATE_IDLE);
+    expect(workqueue_start(&wq) == OM_OK);
+    expect(workqueue_get_state(&wq) == WORKQUEUE_STATE_RUNNING);
+    expect(workqueue_start(&wq) != OM_OK);          /* 重复 start 被拒 */
+    expect(workqueue_stop(&wq) == OM_OK);
+    expect(workqueue_get_state(&wq) == WORKQUEUE_STATE_IDLE);
+    expect(workqueue_stop(&wq) != OM_OK);           /* 重复 stop 被拒 */
+    expect(workqueue_start(&wq) == OM_OK);          /* stop 后可重新 start */
+    expect(workqueue_get_state(&wq) == WORKQUEUE_STATE_RUNNING);
+    expect(workqueue_stop(&wq) == OM_OK);
+    expect(workqueue_deinit(&wq) == OM_OK);
+}
+
+/* 测试3：基本入队→执行 */
+static void t_basic(void)
+{
+    Workqueue wq = {0};
+    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+
+    expect(workqueue_init(&wq, &cfg) == OM_OK);
+    expect(workqueue_start(&wq) == OM_OK);
+
+    OsalSem *sem = make_sem();
+    TW       t;
+    tw_init(&t, 42, sem);
+
+    expect(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    expect(wait_sem(sem, 5000u));
+    expect(t.ex == 1);
+
+    expect(workqueue_stop(&wq) == OM_OK);
+    expect(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+}
+
+/* 测试4：去重——重复入队返回 OM_ERROR_BUSY，仅执行一次 */
+static void t_dedup(void)
+{
+    Workqueue wq = {0};
+    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+
+    expect(workqueue_init(&wq, &cfg) == OM_OK);
+    expect(workqueue_start(&wq) == OM_OK);
+
+    OsalSem *sem = make_sem();
+    TW       t;
+    tw_init(&t, 0, sem);
+
+    expect(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    expect(workqueue_enqueue(&wq, &t.w) == OM_ERROR_BUSY);  /* 去重 */
+    expect(wait_sem(sem, 5000u));
+    expect(t.ex == 1);                                       /* 只执行一次 */
+
+    /* 完成后可重新入队 */
+    expect(workqueue_enqueue(&wq, &t.w) == OM_OK);
+
+    expect(workqueue_stop(&wq) == OM_OK);
+    expect(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+}
+
+/* 测试5：取消队列中尚未执行的工作项 */
+static void t_cancel_pending(void)
+{
+    Workqueue wq = {0};
+    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+
+    expect(workqueue_init(&wq, &cfg) == OM_OK);
+    expect(workqueue_start(&wq) == OM_OK);
+
+    TW t;
+    tw_init(&t, 0, NULL);
+
+    expect(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    expect(work_is_busy(&t.w));
+    expect(workqueue_cancel(&t.w) == OM_OK);
+    expect(!work_is_busy(&t.w));
+
+    /* 给 worker 线程一点时间排空队列（工作项已被移除） */
+    osal_sleep_ms(100u);
+    expect(t.ex == 0);  /* 未执行 */
+
+    expect(workqueue_stop(&wq) == OM_OK);
+    expect(workqueue_deinit(&wq) == OM_OK);
+}
+
+/* 测试6：已完成的工作项无法取消 */
+static void t_cancel_completed(void)
+{
+    Workqueue wq = {0};
+    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+
+    expect(workqueue_init(&wq, &cfg) == OM_OK);
+    expect(workqueue_start(&wq) == OM_OK);
+
+    OsalSem *sem = make_sem();
+    TW       t;
+    tw_init(&t, 0, sem);
+
+    expect(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    expect(wait_sem(sem, 5000u));
+    expect(t.ex == 1);
+
+    /* 已完成工作项不可取消 */
+    expect(workqueue_cancel(&t.w) != OM_OK);
+
+    expect(workqueue_stop(&wq) == OM_OK);
+    expect(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+}
+
+/* 测试7：5 个工作项中取消第 3 个，其余正常执行 */
+static void t_cancel_one_of_many(void)
+{
+    Workqueue wq = {0};
+    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+
+    expect(workqueue_init(&wq, &cfg) == OM_OK);
+    expect(workqueue_start(&wq) == OM_OK);
+
+    OsalSem *sem = make_sem();
+    TW       t[5];
+    int      i;
+    for (i = 0; i < 5; i++) tw_init(&t[i], i, (i == 4) ? sem : NULL);
+
+    for (i = 0; i < 5; i++) expect(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
+    expect(workqueue_cancel(&t[2].w) == OM_OK);  /* 取消第 3 个 */
+
+    expect(wait_sem(sem, 5000u));
+    expect(t[0].ex == 1);
+    expect(t[1].ex == 1);
+    expect(t[2].ex == 0);  /* 已取消 */
+    expect(t[3].ex == 1);
+    expect(t[4].ex == 1);
+
+    expect(workqueue_stop(&wq) == OM_OK);
+    expect(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+}
+
+/* 测试8：取消后重新入队，正常执行 */
+static void t_cancel_reenqueue(void)
+{
+    Workqueue wq = {0};
+    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+
+    expect(workqueue_init(&wq, &cfg) == OM_OK);
+    expect(workqueue_start(&wq) == OM_OK);
+
+    TW t;
+    tw_init(&t, 0, NULL);
+
+    expect(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    expect(workqueue_cancel(&t.w) == OM_OK);
+    expect(!work_is_busy(&t.w));
+
+    /* 取消后重新入队 */
+    OsalSem *sem = make_sem();
+    t.s = sem;
+    expect(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    expect(wait_sem(sem, 5000u));
+    expect(t.ex == 1);
+
+    expect(workqueue_stop(&wq) == OM_OK);
+    expect(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+}
+
+/* 测试9：5 个工作项全部正常执行 */
+static void t_multi(void)
+{
+    Workqueue wq = {0};
+    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+
+    expect(workqueue_init(&wq, &cfg) == OM_OK);
+    expect(workqueue_start(&wq) == OM_OK);
+
+    OsalSem *sem = make_sem();
+    TW       t[5];
+    int      i;
+    for (i = 0; i < 5; i++) tw_init(&t[i], i, (i == 4) ? sem : NULL);
+
+    for (i = 0; i < 5; i++) expect(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
+    expect(wait_sem(sem, 5000u));
+
+    for (i = 0; i < 5; i++) expect(t[i].ex == 1);
+
+    expect(workqueue_stop(&wq) == OM_OK);
+    expect(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+}
+
+/* 测试10：20 项压力测试 */
+static void t_stress(void)
+{
+#define N 20
+    Workqueue wq = {0};
+    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+
+    expect(workqueue_init(&wq, &cfg) == OM_OK);
+    expect(workqueue_start(&wq) == OM_OK);
+
+    OsalSem *sem = make_sem();
+    TW       t[N];
+    int      i;
+    for (i = 0; i < N; i++)
+        tw_init(&t[i], i, (i == N - 1) ? sem : NULL);
+
+    for (i = 0; i < N; i++) expect(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
+    expect(wait_sem(sem, 10000u));
+
+    for (i = 0; i < N; i++) expect(t[i].ex == 1);
+
+    expect(workqueue_stop(&wq) == OM_OK);
+    expect(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+#undef N
+}
+
+/* 测试11：stop 排空——入队后立即 stop，工作项应被执行 */
+static void t_stop_drain(void)
+{
+    Workqueue wq = {0};
+    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+
+    expect(workqueue_init(&wq, &cfg) == OM_OK);
+    expect(workqueue_start(&wq) == OM_OK);
+
+    OsalSem *sem = make_sem();
+    TW       t;
+    tw_init(&t, 42, sem);
+
+    expect(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    /* stop 会排空并等待 worker —— stop 返回后工作项必定已执行 */
+    expect(workqueue_stop(&wq) == OM_OK);
+    expect(t.ex == 1);
+    expect(!work_is_busy(&t.w));
+
+    expect(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+}
+
+/* 测试12：停止后入队被拒绝 */
+static void t_enq_stopped(void)
+{
+    Workqueue wq = {0};
+    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+
+    expect(workqueue_init(&wq, &cfg) == OM_OK);
+    expect(workqueue_start(&wq) == OM_OK);
+    expect(workqueue_stop(&wq) == OM_OK);
+
+    TW t;
+    tw_init(&t, 0, NULL);
+    expect(workqueue_enqueue(&wq, &t.w) == OM_ERROR);  /* 非 RUNNING 状态 */
+
+    expect(workqueue_deinit(&wq) == OM_OK);
+}
+
+/* 测试13：查询函数 —— work_is_busy / workqueue_is_empty */
+static void t_query(void)
+{
+    Workqueue wq = {0};
+    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+
+    expect(workqueue_init(&wq, &cfg) == OM_OK);
+    expect(workqueue_start(&wq) == OM_OK);
+
+    OsalSem *sem = make_sem();
+    TW       t;
+    tw_init(&t, 0, sem);
+
+    expect(!work_is_busy(&t.w));
+    expect(workqueue_is_empty(&wq));
+
+    expect(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    expect(work_is_busy(&t.w));
+    expect(!workqueue_is_empty(&wq));
+
+    expect(wait_sem(sem, 5000u));
+    expect(!work_is_busy(&t.w));
+
+    expect(workqueue_stop(&wq) == OM_OK);
+    expect(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+}
+
+/* --------------------------------------------------------------------------
+ * 测试线程入口 —— 顺序执行全部用例
+ * -------------------------------------------------------------------------- */
+
+static void test_thread_entry(void *arg)
+{
+    (void)arg;
+
+    t_null_params();
+    t_lifecycle();
+    t_basic();
+    t_dedup();
+    t_cancel_pending();
+    t_cancel_completed();
+    t_cancel_one_of_many();
+    t_cancel_reenqueue();
+    t_multi();
+    t_stress();
+    t_stop_drain();
+    t_enq_stopped();
+    t_query();
+
+    g_result.done = 1u;
+    for (;;) osal_sleep_ms(1000u);
+}
+
+/* --------------------------------------------------------------------------
+ * 例程入口
+ * -------------------------------------------------------------------------- */
+
+int main(void)
+{
+    OsalThreadAttr test_attr = {
+        "wq_test",
+        4096u * OSAL_STACK_WORD_BYTES,
+        3u,
+    };
+    OsalThread *test_thread = NULL;
+
+    if (osal_thread_create(&test_thread, &test_attr,
+                           test_thread_entry, NULL) != OSAL_OK)
+        return -1;
+
+    return osal_kernel_start();
+}


### PR DESCRIPTION
## 修改目的

实现 workqueue（工作队列）模块——中断安全的延迟工作调度器，用于将耗时操作从 ISR/高优先级线程上下文卸载到专用 worker 线程。Refs #37

## 涉及的框架维度

- [x] 系统与机制 (OSAL, Sync, Async)
- [x] 文档或示例 (Docs, Sample)

## 变更类型

- [x] 新特性
- [x] 文档更新

## 测试验证说明

### 纯软件逻辑

- 本地 XMake 编译通过（GNU-ARM toolchain, debug mode）
- 13 个测试用例覆盖：生命周期状态机、基本入队执行、去重、取消（pending/completed/one-of-many/re-enqueue）、多工作项、20 项压力测试、stop 排空、停止后入队拒绝、查询函数

### 硬件关联代码

- 目标平台：STM32F407IG + FreeRTOS
- 依赖 osal（信号量/线程/irq_lock）、sync/completion、data_struct/corelist

## 影响范围分析

### 新增对外 API 接口

- `workqueue_init/deinit/start/stop/enqueue/cancel/flush/get_state/is_empty`
- `work_init/work_is_busy`（inline）

### 新增对外数据结构

- `struct Work`（工作项，嵌入调用者结构体使用）
- `struct Workqueue`（工作队列实例，直接声明使用）
- `struct WorkqueueConfig`（配置参数）

### OSAL 新增接口

- `osal_irq_lock/unlock`（上下文自动分派临界区）
- `osal_sem_post_auto`（上下文自动分派信号量释放）

## Issue 关联与关闭策略

Refs #37

## 提交者自查清单

- [x] 代码风格符合规范，变量/函数命名语义清晰
- [x] 核心复杂逻辑已添加中文注释
- [x] 本地分支已基于最新 `integration` 同步，无冲突
- [x] 提交序列已按单一职责拆分（OSAL 改动 → workqueue 核心 → 测试示例）
- [x] 跨层接口/签名变更已在同一提交内闭环
- [x] 未夹带无关注释、空行或排版改动
- [x] 提交信息符合 `类型(作用域): 简短描述` 格式