### PR TITLE
feat(drivers): GPIO PAL 子系统实现

### DIFF
--- a/lib/drivers/docs/gpio_design.md
+++ b/lib/drivers/docs/gpio_design.md
@@ -1,0 +1,400 @@
+# GPIO 子系统设计决策
+
+> 本文档记录 GPIO 驱动子系统在详细设计前的关键决策及其理由。
+> 仅供设计参考，不包含具体实现方案。
+
+---
+
+## 一、决策总表
+
+| 编号 | 维度 | 决策 | 参考 |
+|------|------|------|------|
+| D1 | 职责边界 | GPIO I/O + 电气配置，不含引脚复用 | RT-Thread PIN |
+| D2 | 架构集成 | 内部 Device 注册 + 对外专用 API | RT-Thread PIN |
+| D3 | 抽象粒度 | 每控制器一 Device，通过控制器名+偏移寻址 | Zephyr |
+| D4 | 引脚标识 | GpioPinSpec + GpioPin 双类型（Spec 编译时声明，Pin 运行时句柄） | Linux gpiod |
+| D5 | 配置模型 | GpioPinConfig 配置结构体 | STM32 HAL / ESP-IDF |
+| D6 | 中断模型 | 直接 ISR 回调 | Zephyr / RT-Thread |
+| D7 | 批量操作 | 引脚级 + 端口级批量 | Zephyr |
+| D8 | 依赖一致性 | 依赖 core + osal（仅 IRQ 路径），与分层规范一致 | — |
+| D9 | 控制器结构 | GpioController 内嵌 Device parent，BSP 内嵌 GpioController parent | OM CAN 模式 |
+| D10 | 线程安全 | 仅保护 IRQ 回调表（关中断），读写/配置不加锁 | RT-Thread / Zephyr |
+| D11 | 设备类型 | Device 新增 DeviceType 字段，gpio_pin_get 校验类型 | — |
+| D12 | IRQ 能力 | 控制器注册时声明 caps 位图，框架层校验请求模式 | Zephyr |
+| D13 | 端口级语义 | 端口级 API 使用物理电平，引脚级使用逻辑电平 | Zephyr（提供 raw/logical 双接口） |
+| D14 | BSP attach_irq | 仅配置 EXTI 路由和 NVIC，不调用 HAL_GPIO_Init，不修改电气配置 | — |
+
+---
+
+## 二、各项决策详述
+
+### D1: 职责边界 — GPIO I/O + 电气配置
+
+**包含**：
+- 方向控制（输入/输出）
+- 电平读写、翻转
+- 上下拉配置（无/上拉/下拉）
+- 驱动模式（推挽/开漏）
+- 驱动强度（低/中/高，硬件相关，不支持的 BSP 返回 OM_ENOTSUP）
+- 输出初始值
+- 中断（边沿/电平触发）
+
+**不包含**：
+- 引脚复用（alternate function 选择）—— 由各外设 BSP 自行处理，维持现状
+
+**理由**：
+引脚复用与具体 SoC 的外设路由机制深度耦合（如 STM32 的 AF 映射表），抽象代价高且收益有限。当前 CAN/Serial 等外设的 BSP 层已通过直接调用厂商 HAL 完成引脚复用，引入新抽象层会破坏已有实现。GPIO 子系统聚焦"通用 GPIO"场景（LED、按键、片选、使能信号等），职责清晰，边界明确。
+
+---
+
+### D2: 架构集成 — 内部 Device + 专用 API
+
+**决策**：
+- GPIO 控制器在框架内部通过 Device 模型注册管理（参与设备链表、可 `device_find()`）
+- 对外暴露专用 `gpio_pin_xxx` / `gpio_port_xxx` API，用户不直接操作 Device 的 read/write/control
+
+**理由**：
+GPIO 的操作语义（按引脚寻址的位操作）与 Device 模型的 read/write（缓冲区语义）不匹配。若强行映射到 `device_read/device_write`，参数编码不直观且增加用户理解成本。专用 API 能提供更自然的调用方式，同时内部复用 Device 基础设施（注册、查找、生命周期）保持框架一致性。
+
+---
+
+### D3: 抽象粒度 — 每控制器一 Device
+
+**决策**：
+- 每个 GPIO 控制器（片上端口或外部扩展器）注册为独立 Device
+- 各控制器声明 `pin_count`（管理引脚数）
+- 用户通过 `GpioPin` 句柄（含已解析的 `ctrl` 指针）操作引脚，框架通过 `ctrl` 直接路由到对应控制器
+
+**理由**：
+全局单例模式简单，但无法支持 GPIO 扩展器（I2C/SPI 芯片如 PCF8574、SX1509）。每控制器一 Device 的模式天然支持多控制器，且初始复杂度增加有限（核心仅多一步 pin 号→控制器的查找）。控制器的 ops 函数表按控制器粒度注册，不同控制器可有不同实现（片上 GPIO 直接寄存器操作 vs I2C 扩展器总线操作）。
+
+---
+
+### D4: 引脚标识 — GpioPinSpec + GpioPin 双类型
+
+**决策**：
+```c
+// 编译时声明（static const，零运行时构建开销）
+typedef struct {
+    const char *controller;  // 控制器名称，如 "gpio0"
+    uint8_t offset;          // 控制器内引脚偏移
+    uint32_t flags;          // 引脚属性标志（ACTIVE_LOW 等）
+} GpioPinSpec;
+
+// 运行时句柄（gpio_pin_get() 解析一次，后续零查找开销）
+typedef struct {
+    GpioController *ctrl;    // 已解析的控制器指针
+    uint8_t offset;          // 控制器内引脚偏移
+    uint32_t flags;          // 引脚属性标志
+} GpioPin;
+```
+
+使用方式：
+```c
+static const GpioPinSpec led_spec = { "gpio0", 19, 0 };
+GpioPin led = gpio_pin_get(&led_spec);
+if (!gpio_pin_valid(led)) return OM_ENODEV;
+gpio_pin_write(led, 1);  // 直接通过 ctrl 指针，无字符串查找
+```
+
+**理由**：
+- **分离关注点**：`GpioPinSpec` 是平台描述（可 static const），`GpioPin` 是运行时句柄（含已解析指针）
+- **ISR 安全**：`GpioPin` 的 `ctrl` 指针在解析时确定，ISR 中高频调用 `gpio_pin_write` 无字符串查找开销
+- **跨平台一致性**：结构体通过控制器名 + offset 统一语义，不同平台编码规则差异被 `gpio_pin_get()` 封装
+- **可扩展**：`flags` 字段承载 ACTIVE_LOW 等逻辑电平信息
+
+---
+
+### D5: 配置模型 — GpioPinConfig 配置结构体
+
+**决策**：
+```c
+typedef struct {
+    GpioDirection direction;      // INPUT / OUTPUT
+    GpioPull pull;                // NONE / UP / DOWN
+    GpioDrive drive;              // PUSH_PULL / OPEN_DRAIN
+    GpioDriveStrength speed;      // LOW / MEDIUM / HIGH
+    bool init_high;               // 输出初始逻辑电平（输出时有效，ACTIVE_LOW 自动反转）
+} GpioPinConfig;
+```
+通过 `gpio_pin_configure(GpioPin pin, const GpioPinConfig *cfg)` 一次性配置。
+
+**init_high 语义**：采用**逻辑电平**（与 `gpio_pin_write` / `gpio_pin_read` 一致）。框架层在传递给 BSP 前对 `GPIO_FLAG_ACTIVE_LOW` 引脚自动反转物理电平，确保用户始终用统一逻辑语义操作引脚。
+
+**理由**：
+- 各属性独立字段，自文档化，用户无需记忆位域宏含义
+- 与 STM32 HAL 的 `GPIO_InitTypeDef`、ESP-IDF 的 `gpio_config_t` 模式一致，嵌入式开发者熟悉
+- 扩展性好：新增属性只需添加字段，不影响已有代码
+- 比枚举组合（`PIN_MODE_OUTPUT_OD`）更灵活，不会组合爆炸
+
+---
+
+### D6: 中断模型 — 直接 ISR 回调
+
+**决策**：
+```c
+OmRet gpio_pin_attach_irq(GpioPin pin, GpioIrqMode mode,
+                           void (*callback)(void *arg), void *arg);
+OmRet gpio_pin_irq_enable(GpioPin pin, bool enable);
+```
+- `attach_irq`：注册回调函数和触发模式，不使能硬件中断
+- `irq_enable`：使能/禁用硬件中断
+
+回调在 ISR 上下文中执行，用户回调必须遵守 ISR 约束（不可阻塞、不可耗时）。
+
+**理由**：
+- 延迟最低，适合机器人场景中的实时响应（编码器脉冲、限位开关、紧急停止）
+- attach/enable 分离允许先注册回调再条件使能，灵活控制中断生命周期
+- 不引入 osal/sync/ipc 依赖，GPIO 子系统保持最轻依赖（仅 core）
+- 用户若需任务级处理，可在回调中自行使用 osal 原语（信号量 give、队列发送等）
+
+---
+
+### D7: 批量操作 — 引脚级 + 端口级批量
+
+**决策**：
+- **引脚级 API**：`gpio_pin_write` / `gpio_pin_read` / `gpio_pin_toggle` 等，操作单个 GpioPinSpec
+- **端口级批量 API**：`gpio_port_write_masked` / `gpio_port_read` 等，按控制器名 + 位掩码操作多引脚
+
+**理由**：
+引脚级 API 覆盖绝大多数场景，端口级批量操作为并行接口、LED 矩阵、多路片选等高性能场景提供硬件原生效率。端口级 API 直接映射到硬件寄存器的掩码写入，不经过逐引脚循环，利用了 GPIO 控制器的原子多引脚操作能力。
+
+---
+
+### D8: 依赖一致性
+
+**决策**：
+- GPIO 子系统位于 `lib/drivers/`，依赖 `core`（类型/错误码/atomic）+ `osal`（`osal_irq_lock/unlock`，仅 IRQ 管理路径使用）
+- API 头文件放入 `tar_awapi_driver`（headeronly target），实现放入 `tar_awdrivers`（static target）
+- 裁剪宏：`OM_USE_HAL_GPIO`，在 `om_config.h` 中定义
+- PAL 入口：在 `pal_dev.h` 中通过条件编译包含 GPIO 头文件
+- 不依赖 sync/ipc/services/systems，不 include bsp 头文件
+
+**理由**：
+GPIO 是基础驱动，被其他模块使用（如 SPI 驱动的片选引脚），依赖越轻越好。热路径（pin_read/pin_write）仅依赖 core，IRQ 回调表保护需要 `osal_irq_lock/unlock`。`drivers → osal` 依赖方向符合分层规范。
+
+---
+
+### D9: 控制器结构体 — 沿用 OM PAL 模式
+
+**决策**：
+框架层 `GpioController` 内嵌 `Device parent`，BSP 层结构体内嵌 `GpioController parent`。与 CAN 的 `HalCanHandler` + `BspCan` 模式完全一致。
+
+```c
+// 框架层（lib/drivers/）
+typedef struct GpioController {
+    Device parent;               // 内嵌 Device，参与设备链表
+    const GpioOps *ops;          // BSP 注入的硬件操作函数表
+    uint8_t pin_count;           // 管理的引脚数量
+    uint32_t caps;               // IRQ 能力位图
+    void *priv;                  // BSP 私有数据
+    // IRQ 回调表（框架层管理）
+    struct GpioIrqHdr *irq_hdrs;
+} GpioController;
+
+// BSP 层（platform/bsp/boards/<board>/）
+typedef struct BspGpio {
+    GPIO_TypeDef *port;          // STM32 HAL 端口指针（放首位方便强转）
+    GpioController parent;       // 框架层父结构体
+    char *name;
+    uint8_t irq_priority;        // NVIC 优先级（板级配置）
+} BspGpio;
+```
+
+**理由**：
+- 与 CAN/Serial 的 PAL 适配模式一致，BSP 开发者无需学习新模式
+- `Device.parent` 保证控制器可被 `device_find()` 查找（`gpio_pin_get()` 内部使用）
+- BSP 通过 `GpioController.priv` 或 container_of 访问私有数据
+
+---
+
+### D10: 线程安全 — 仅保护 IRQ 回调表
+
+**决策**：
+- `gpio_pin_attach_irq` / `gpio_pin_detach_irq` 内部关中断保护回调表，防止与 ISR 并发修改
+- `gpio_pin_write` / `gpio_pin_read` / `gpio_pin_toggle` / `gpio_pin_configure` / `gpio_pin_irq_enable` 不加锁
+- 端口级批量操作不加锁
+- `gpio_controller_register` 仅在初始化阶段调用
+
+```c
+// attach_irq 内部
+OmRet gpio_pin_attach_irq(GpioPin pin, GpioIrqMode mode,
+                           void (*cb)(void *), void *arg) {
+    int key = osal_irq_lock();
+    irq_hdrs[offset].callback = cb;
+    irq_hdrs[offset].arg = arg;
+    osal_irq_unlock(key);
+    return OM_OK;
+}
+```
+
+**调用者义务**：
+- 同一引脚的 configure 不会与 write/read 并发（方向变更期间不应读写）
+- 端口级批量操作不会在多上下文中对同一控制器并发
+- `gpio_controller_register` 仅在初始化阶段调用
+
+**理由**：
+- 引脚读写为单寄存器操作（MCU 的 BSRR/BRR 等位操作寄存器硬件保证原子），加锁无意义
+- IRQ 回调表是唯一真正的竞态风险点——`attach_irq` 修改表时 ISR 可能正在查表调用，必须保护
+- 与 RT-Thread（`rt_hw_interrupt_disable`）、Zephyr（`irq_lock`）、ESP-IDF（spinlock）做法一致
+- 关中断保护仅覆盖回调表赋值（几条指令），对 ISR 延迟影响可忽略
+- 此决策引入对 osal 的 `osal_irq_lock/unlock` 依赖，但仅限于 IRQ 管理路径，不影响 pin_read/pin_write 的零依赖热路径
+
+---
+
+## 三、API 轮廓（非最终接口）
+
+以下为基于上述决策的 API 形态预览，仅供设计参考：
+
+```c
+/* ===== 引脚标识（双类型） ===== */
+
+// 编译时声明（static const）
+typedef struct {
+    const char *controller;      // 控制器名称
+    uint8_t offset;              // 控制器内引脚偏移
+    uint32_t flags;              // GPIO_FLAG_ACTIVE_LOW 等
+} GpioPinSpec;
+
+// 运行时句柄（gpio_pin_get() 解析一次，后续零查找开销）
+typedef struct GpioPin {
+    struct GpioController *ctrl; // 已解析的控制器指针
+    uint8_t offset;              // 控制器内引脚偏移
+    uint32_t flags;              // 引脚属性标志
+} GpioPin;
+
+// 解析 + 有效性检查
+GpioPin gpio_pin_get(const GpioPinSpec *spec);
+bool    gpio_pin_valid(GpioPin pin);
+
+/* ===== 引脚配置 ===== */
+typedef enum { GPIO_DIR_INPUT, GPIO_DIR_OUTPUT } GpioDirection;
+typedef enum { GPIO_PULL_NONE, GPIO_PULL_UP, GPIO_PULL_DOWN } GpioPull;
+typedef enum { GPIO_DRIVE_PUSH_PULL, GPIO_DRIVE_OPEN_DRAIN } GpioDrive;
+typedef enum { GPIO_SPEED_LOW, GPIO_SPEED_MEDIUM, GPIO_SPEED_HIGH } GpioDriveStrength;
+
+typedef struct {
+    GpioDirection direction;
+    GpioPull pull;
+    GpioDrive drive;
+    GpioDriveStrength speed;
+    bool init_high;               // 输出初始逻辑电平（ACTIVE_LOW 自动反转）
+} GpioPinConfig;
+
+/* ===== 中断 ===== */
+typedef enum {
+    GPIO_IRQ_EDGE_RISING,
+    GPIO_IRQ_EDGE_FALLING,
+    GPIO_IRQ_EDGE_BOTH,
+    GPIO_IRQ_LEVEL_HIGH,
+    GPIO_IRQ_LEVEL_LOW,
+} GpioIrqMode;
+
+/* ===== 引脚级 API（以 GpioPin 句柄为参数） ===== */
+OmRet   gpio_pin_configure(GpioPin pin, const GpioPinConfig *cfg);
+void    gpio_pin_write(GpioPin pin, uint8_t value);
+uint8_t gpio_pin_read(GpioPin pin);
+void    gpio_pin_toggle(GpioPin pin);
+
+/* ===== 中断 API ===== */
+OmRet gpio_pin_attach_irq(GpioPin pin, GpioIrqMode mode,
+                           void (*callback)(void *arg), void *arg);
+OmRet gpio_pin_detach_irq(GpioPin pin);
+OmRet gpio_pin_irq_enable(GpioPin pin, bool enable);
+
+/* ===== 端口级批量 API ===== */
+typedef struct {
+    GpioController *ctrl;
+} GpioPort;
+
+GpioPort gpio_port_get(const char *controller);
+bool     gpio_port_valid(GpioPort port);
+OmRet   gpio_port_write_masked(GpioPort port, uint32_t mask, uint32_t value);
+OmRet   gpio_port_set_bits(GpioPort port, uint32_t pins);
+OmRet   gpio_port_clear_bits(GpioPort port, uint32_t pins);
+OmRet   gpio_port_toggle_bits(GpioPort port, uint32_t pins);
+uint32_t gpio_port_read(GpioPort port);
+
+/* ===== 控制器注册（BSP 侧） ===== */
+typedef struct GpioOps {
+    OmRet   (*pin_configure)(GpioController *ctrl, uint8_t offset, const GpioPinConfig *cfg);
+    void    (*pin_write)(GpioController *ctrl, uint8_t offset, uint8_t value);
+    uint8_t (*pin_read)(GpioController *ctrl, uint8_t offset);
+    void    (*pin_toggle)(GpioController *ctrl, uint8_t offset);
+    OmRet   (*pin_attach_irq)(GpioController *ctrl, uint8_t offset, GpioIrqMode mode,
+                               void (*cb)(void *), void *arg);
+    OmRet   (*pin_irq_enable)(GpioController *ctrl, uint8_t offset, bool enable);
+    // 端口级（可选，NULL 表示不支持）
+    OmRet   (*port_write_masked)(GpioController *ctrl, uint32_t mask, uint32_t value);
+    OmRet   (*port_set_bits)(GpioController *ctrl, uint32_t pins);
+    OmRet   (*port_clear_bits)(GpioController *ctrl, uint32_t pins);
+    OmRet   (*port_toggle_bits)(GpioController *ctrl, uint32_t pins);
+    uint32_t (*port_read)(GpioController *ctrl);
+} GpioOps;
+
+OmRet gpio_controller_register(const char *name,
+                                uint8_t pin_count,
+                                uint32_t caps, const GpioOps *ops, void *priv);
+
+/* ===== 控制器结构体（框架内部） ===== */
+typedef struct GpioController {
+    Device parent;               // 内嵌 Device
+    const GpioOps *ops;          // BSP 注入的硬件操作函数表
+    uint8_t pin_start;
+    uint8_t pin_count;
+    void *priv;                  // BSP 私有数据
+    struct GpioIrqHdr *irq_hdrs; // 中断回调表
+} GpioController;
+```
+
+---
+
+## 四、迭代补充决策（代码审查后）
+
+### D11: 设备类型标识
+
+**决策**：
+`Device` 结构体新增 `DeviceType type` 字段，`gpio_pin_get()` / `gpio_port_get()` 查找设备后校验 `type == DEVICE_TYPE_GPIO`，非 GPIO 设备拒绝访问。
+
+**理由**：
+`device_find()` 返回任意 `Device*`，直接强转为 `GpioController*` 无类型验证，存在未定义行为风险。通过类型标识在框架层拦截非法访问，开销仅为一次整数比较。
+
+### D12: IRQ 能力位图
+
+**决策**：
+`GpioController` 新增 `uint32_t caps` 字段，注册时声明支持的 IRQ 触发模式。位号与 `GpioIrqMode` 枚举值对齐，`1U << mode` 直接查询。`gpio_pin_attach_irq()` 在框架层校验 `caps & (1U << mode)`，不支持时返回 `OM_ERROR_NOT_SUPPORT`。
+
+```c
+#define GPIO_CAP_IRQ_EDGE_RISING   (1U << GPIO_IRQ_EDGE_RISING)
+#define GPIO_CAP_IRQ_EDGE_FALLING  (1U << GPIO_IRQ_EDGE_FALLING)
+#define GPIO_CAP_IRQ_EDGE_BOTH     (1U << GPIO_IRQ_EDGE_BOTH)
+#define GPIO_CAP_IRQ_LEVEL_HIGH    (1U << GPIO_IRQ_LEVEL_HIGH)
+#define GPIO_CAP_IRQ_LEVEL_LOW     (1U << GPIO_IRQ_LEVEL_LOW)
+```
+
+STM32F4 EXTI 仅支持边沿触发，BSP 注册时传入 `GPIO_CAP_IRQ_EDGE_RISING | GPIO_CAP_IRQ_EDGE_FALLING | GPIO_CAP_IRQ_EDGE_BOTH`。
+
+**理由**：
+PAL 枚举定义了 5 种模式，但具体硬件可能只支持子集（如 STM32 EXTI 不支持电平触发）。能力位图让用户在调用 `attach_irq` 时立即得到明确的"不支持"反馈，而非依赖 BSP 层的 switch-default。
+
+### D13: 端口级 API 物理电平语义
+
+**决策**：
+端口级 API（`gpio_port_write_masked` 等）使用**物理电平**语义，不经过 `GPIO_FLAG_ACTIVE_LOW` 反转。引脚级 API（`gpio_pin_write` 等）使用逻辑电平语义。
+
+**理由**：
+Zephyr 为端口级 API 同时提供逻辑和 `_raw` 物理变体，当前设计出于简洁性考虑仅提供物理接口。`GpioPort` 不携带 per-pin flags，无法实现 per-pin ACTIVE_LOW 反转。后续可按需扩展逻辑变体。使用端口级 API 的场景（并行接口、LED 矩阵）通常已知硬件布局，物理语义更直观。
+
+### D14: BSP attach_irq 不修改电气配置
+
+**决策**：
+BSP 层 `pin_attach_irq` 实现仅操作 EXTI 相关寄存器（SYSCFG EXTICR、EXTI RTSR/FTSR/IMR、NVIC），不调用 `HAL_GPIO_Init`，不修改 MODER/PUPDR/OSPEEDR 等电气配置寄存器。用户需先通过 `gpio_pin_configure()` 将引脚配置为输入模式（含所需的上下拉），再调用 `attach_irq`。
+
+**理由**：
+`HAL_GPIO_Init` 会重写所有引脚配置，导致用户通过 `gpio_pin_configure` 设置的 pull 被覆盖。将电气配置与中断配置解耦后，两者职责清晰：`configure` 管电气，`attach_irq` 管路由和触发。NVIC 优先级从 BSP 板级配置（`BspGpio.irq_priority`）读取，不再硬编码。
+
+---
+
+## 五、参考来源
+
+调研详见 `docs/gpio_subsystem_survey.md`（workspace 目录）。

--- a/lib/drivers/include/drivers/model/device.h
+++ b/lib/drivers/include/drivers/model/device.h
@@ -14,6 +14,14 @@
 extern "C" {
 #endif
 
+/** 设备类型标识，用于 device_find 后的类型安全校验 */
+typedef enum {
+    DEVICE_TYPE_UNKNOWN = 0,
+    DEVICE_TYPE_GPIO,
+    DEVICE_TYPE_CAN,
+    DEVICE_TYPE_SERIAL,
+} DeviceType;
+
 typedef struct DevInterface  DevInterface;
 typedef struct Device  Device;
 
@@ -45,6 +53,7 @@ typedef struct Device {
     DevInterface* interface;
     DevAttr priv;
     void *handle;
+    DeviceType type;
     ListHead list;
 } Device;
 

--- a/lib/drivers/include/drivers/peripheral/gpio/pal_gpio_dev.h
+++ b/lib/drivers/include/drivers/peripheral/gpio/pal_gpio_dev.h
@@ -1,0 +1,567 @@
+/**
+ * @file    pal_gpio_dev.h
+ * @defgroup GPIO GPIO 子系统
+ * @brief   GPIO PAL 设备驱动接口
+ * @details
+ * GPIO 子系统提供通用引脚 I/O、电气配置和中断管理能力。
+ *
+ * 核心概念：
+ * - **GpioPinSpec** — 编译时引脚描述符（控制器名 + 偏移），可声明为 static const
+ * - **GpioPin** — 运行时引脚句柄，由 gpio_pin_get() 从 GpioPinSpec 解析获得，
+ *   后续操作直接通过已解析的控制器指针，无需字符串查找
+ * - **GpioPort** — 端口句柄，由 gpio_port_get() 解析，用于端口级批量操作
+ * - **GpioController** — GPIO 控制器，内嵌 Device 参与设备链表管理
+ *
+ * 线程安全：
+ * - gpio_pin_attach_irq / gpio_pin_detach_irq 内部关中断保护回调表
+ * - gpio_pin_write / read / toggle / configure / irq_enable 不加锁
+ * - 调用者需保证同一引脚的 configure 不与 write/read 并发
+ *
+ * @see     lib/drivers/docs/gpio_design.md — 设计决策详述
+ */
+
+#ifndef __PAL_GPIO_DEV_H__
+#define __PAL_GPIO_DEV_H__
+
+#include "drivers/model/device.h"
+#include "osal/osal_core.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name 引脚标志
+ * @{ */
+
+/** 低电平有效标志。
+ *  置位后 gpio_pin_write / gpio_pin_read 自动反转物理电平。 */
+#define GPIO_FLAG_ACTIVE_LOW (0x01U)
+
+/** @} */
+
+/**
+ * @name 枚举类型
+ * @{ */
+
+/** 引脚方向 */
+typedef enum {
+    GPIO_DIR_INPUT  = 0U,  /**< 输入模式 */
+    GPIO_DIR_OUTPUT = 1U,  /**< 输出模式 */
+} GpioDirection;
+
+/** 上下拉配置 */
+typedef enum {
+    GPIO_PULL_NONE = 0U,  /**< 无上下拉 */
+    GPIO_PULL_UP   = 1U,  /**< 上拉 */
+    GPIO_PULL_DOWN = 2U,  /**< 下拉 */
+} GpioPull;
+
+/** 驱动模式 */
+typedef enum {
+    GPIO_DRIVE_PUSH_PULL  = 0U,  /**< 推挽输出 */
+    GPIO_DRIVE_OPEN_DRAIN = 1U,  /**< 开漏输出 */
+} GpioDrive;
+
+/** 驱动强度（硬件相关，不支持时 BSP 返回 OM_ENOTSUP） */
+typedef enum {
+    GPIO_SPEED_LOW    = 0U,  /**< 低驱动强度 */
+    GPIO_SPEED_MEDIUM = 1U,  /**< 中驱动强度 */
+    GPIO_SPEED_HIGH   = 2U,  /**< 高驱动强度 */
+} GpioDriveStrength;
+
+/** 中断触发模式 */
+typedef enum {
+    GPIO_IRQ_EDGE_RISING  = 0U,  /**< 上升沿触发 */
+    GPIO_IRQ_EDGE_FALLING = 1U,  /**< 下降沿触发 */
+    GPIO_IRQ_EDGE_BOTH    = 2U,  /**< 双边沿触发 */
+    GPIO_IRQ_LEVEL_HIGH   = 3U,  /**< 高电平触发 */
+    GPIO_IRQ_LEVEL_LOW    = 4U,  /**< 低电平触发 */
+} GpioIrqMode;
+
+/** @} */
+
+/**
+ * @name IRQ 能力标志
+ * @details 注册控制器时通过 caps 参数声明支持的 IRQ 触发模式。
+ *          框架层 gpio_pin_attach_irq 会校验请求的模式是否在 caps 中声明。
+ *          位号与 #GpioIrqMode 枚举值对齐，可直接用 `1U << mode` 查询。
+ * @{ */
+
+#define GPIO_CAP_IRQ_EDGE_RISING   (1U << GPIO_IRQ_EDGE_RISING)   /**< 支持上升沿触发 */
+#define GPIO_CAP_IRQ_EDGE_FALLING  (1U << GPIO_IRQ_EDGE_FALLING)  /**< 支持下降沿触发 */
+#define GPIO_CAP_IRQ_EDGE_BOTH     (1U << GPIO_IRQ_EDGE_BOTH)     /**< 支持双边沿触发 */
+#define GPIO_CAP_IRQ_LEVEL_HIGH    (1U << GPIO_IRQ_LEVEL_HIGH)    /**< 支持高电平触发 */
+#define GPIO_CAP_IRQ_LEVEL_LOW     (1U << GPIO_IRQ_LEVEL_LOW)     /**< 支持低电平触发 */
+
+/** @} */
+
+/* ===== 前向声明 ===== */
+
+typedef struct GpioController GpioController;
+typedef struct GpioOps GpioOps;
+
+/**
+ * @name 引脚标识（双类型：Spec 编译时声明，Pin 运行时句柄）
+ * @{ */
+
+/**
+ * @brief  编译时引脚描述符
+ * @details 可声明为 static const，零运行时构建开销。
+ *          通过 gpio_pin_get() 解析为运行时句柄 #GpioPin。
+ *
+ * @code
+ * static const GpioPinSpec led_spec = { "gpioa", 5, 0 };
+ * @endcode
+ */
+typedef struct {
+    const char *controller;  /**< 控制器名称，由 BSP 定义（如 "gpioa"） */
+    uint8_t offset;          /**< 控制器内引脚偏移（从 0 开始） */
+    uint32_t flags;          /**< 引脚属性标志，如 #GPIO_FLAG_ACTIVE_LOW */
+} GpioPinSpec;
+
+/**
+ * @brief  运行时引脚句柄
+ * @details 由 gpio_pin_get() 从 #GpioPinSpec 解析获得，包含已解析的控制器指针。
+ *          后续操作直接通过 ctrl 指针路由，零字符串查找开销，ISR 安全。
+ *
+ * @code
+ * GpioPin led = gpio_pin_get(&led_spec);
+ * if (!gpio_pin_valid(led)) return OM_ENODEV;
+ * gpio_pin_write(led, 1);
+ * @endcode
+ */
+typedef struct {
+    GpioController *ctrl;  /**< 已解析的控制器指针，NULL 表示无效 */
+    uint8_t offset;        /**< 控制器内引脚偏移 */
+    uint32_t flags;        /**< 引脚属性标志 */
+} GpioPin;
+
+/** @} */
+
+/**
+ * @name 端口句柄
+ * @{ */
+
+/**
+ * @brief  端口句柄
+ * @details 由 gpio_port_get() 解析获得，用于端口级批量操作。
+ */
+typedef struct {
+    GpioController *ctrl;  /**< 已解析的控制器指针，NULL 表示无效 */
+} GpioPort;
+
+/** @} */
+
+/**
+ * @name 引脚配置
+ * @{ */
+
+/**
+ * @brief  引脚配置结构体
+ * @details 通过 gpio_pin_configure() 一次性应用所有电气属性。
+ */
+typedef struct {
+    GpioDirection direction;      /**< 引脚方向：输入或输出 */
+    GpioPull pull;                /**< 上下拉配置 */
+    GpioDrive drive;              /**< 驱动模式：推挽或开漏 */
+    GpioDriveStrength speed;      /**< 驱动强度 */
+    bool init_high;               /**< 输出初始逻辑电平（仅输出模式有效）。
+                                        true = 逻辑高（ACTIVE_LOW 引脚自动反转物理电平） */
+} GpioPinConfig;
+
+/** @} */
+
+/**
+ * @brief  中断回调描述（框架内部使用，用户无需直接操作）
+ */
+typedef struct {
+    void (*callback)(void *arg);  /**< 用户回调函数 */
+    void *arg;                    /**< 回调函数参数 */
+    GpioIrqMode mode;             /**< 中断触发模式 */
+} GpioIrqHdr;
+
+/**
+ * @brief  GPIO 控制器
+ * @details 每个控制器（片上端口或外部扩展器）注册为独立 Device。
+ *          BSP 层通过 container_of 或 priv 指针访问私有数据。
+ */
+struct GpioController {
+    Device parent;                /**< 内嵌 Device，参与设备链表管理 */
+    const GpioOps *ops;           /**< BSP 注入的硬件操作函数表 */
+    uint8_t pin_count;            /**< 管理的引脚数量 */
+    uint32_t caps;                /**< IRQ 能力位图，见 GPIO_CAP_IRQ_xxx */
+    void *priv;                   /**< BSP 私有数据指针 */
+    GpioIrqHdr *irq_hdrs;         /**< 中断回调表（框架层管理） */
+};
+
+/**
+ * @brief  BSP 硬件操作函数表
+ * @details BSP 层实现此函数表并通过 gpio_controller_register() 注入到控制器。
+ *
+ * **通用约定**：
+ * - `ctrl`   — 当前控制器指针，通过 `ctrl->parent.handle` 或 `ctrl->priv` 获取 BSP 私有数据
+ * - `offset` — 控制器内引脚偏移，框架已校验范围 [0, pin_count)，BSP 无需再次校验
+ * - 引脚级 ops 为**必选**（注册时校验非 NULL），端口级 ops 为可选（NULL = 不支持）
+ * - 所有回调需**同步完成**
+ *
+ * **物理电平约定**：
+ * - 框架层在调用 ops 前已完成 ACTIVE_LOW 反转，BSP 收到的 value 均为**物理电平**
+ * - BSP 返回给框架的 read 值也必须是**物理电平**，由框架负责向用户呈现逻辑电平
+ *
+ * **调用上下文**：
+ * - pin_write / pin_read / pin_toggle — 可能在**线程或 ISR** 中被调用，禁止阻塞
+ * - pin_configure / pin_attach_irq / pin_irq_enable — 仅在**线程**上下文调用
+ * - 端口级 ops — 仅在**线程**上下文调用
+ */
+struct GpioOps {
+
+    /**
+     * @brief  配置引脚电气属性
+     *
+     * @details 一次性设置引脚方向、上下拉、驱动模式、驱动强度和初始电平。
+     *          cfg 为栈上副本，BSP 可直接读取无需拷贝；函数返回后指针失效。
+     *          对于输出模式，cfg->init_high 已由框架层完成 ACTIVE_LOW 反转，
+     *          BSP 应将此值作为物理初始电平直接写入后切换模式，避免毛刺。
+     *
+     * @param[in] ctrl   当前控制器
+     * @param[in] offset 引脚偏移 [0, pin_count)
+     * @param[in] cfg    电气配置（物理电平语义）
+     * @return OM_OK 成功，OM_ENOTSUP 不支持请求的配置（如 speed），
+     *         其他负值表示硬件错误
+     *
+     * @note 调用后引脚应立即处于 cfg 所描述的状态，无中间态
+     */
+    OmRet (*pin_configure)(GpioController *ctrl, uint8_t offset,
+                           const GpioPinConfig *cfg);
+
+    /**
+     * @brief  写引脚物理电平
+     *
+     * @details 将引脚驱动为指定物理电平。可能在 ISR 中被高频调用，
+     *          实现应使用硬件原子操作，避免 read-modify-write。
+     *
+     * @param[in] ctrl   当前控制器
+     * @param[in] offset 引脚偏移 [0, pin_count)
+     * @param[in] value  物理电平：0 = 低，非 0 = 高
+     *
+     * @note 可在 ISR 上下文调用，禁止阻塞
+     */
+    void (*pin_write)(GpioController *ctrl, uint8_t offset, uint8_t value);
+
+    /**
+     * @brief  读引脚物理电平
+     *
+     * @details 读取引脚当前物理电平。对输出引脚应读实际引脚状态，
+     *          而非输出寄存器，以反映外部电路的影响。
+     *
+     * @param[in] ctrl   当前控制器
+     * @param[in] offset 引脚偏移 [0, pin_count)
+     * @return 0 物理低电平，1 物理高电平
+     *
+     * @note 可在 ISR 上下文调用，禁止阻塞
+     */
+    uint8_t (*pin_read)(GpioController *ctrl, uint8_t offset);
+
+    /**
+     * @brief  翻转引脚物理电平
+     *
+     * @details 将引脚物理电平取反。若硬件支持原子翻转应直接使用，
+     *          否则等效于 read → write 反值。
+     *
+     * @param[in] ctrl   当前控制器
+     * @param[in] offset 引脚偏移 [0, pin_count)
+     *
+     * @note 可在 ISR 上下文调用，禁止阻塞
+     */
+    void (*pin_toggle)(GpioController *ctrl, uint8_t offset);
+
+    /**
+     * @brief  配置中断路由和触发方式
+     *
+     * @details 将指定引脚的中断线路由到当前控制器，配置边沿/电平触发方式，
+     *          并设置中断优先级。**不应修改引脚的电气配置**（方向、上下拉等）。
+     *          **不应使能中断**，由 pin_irq_enable 控制。
+     *
+     * @param[in] ctrl   当前控制器
+     * @param[in] offset 引脚偏移 [0, pin_count)
+     * @param[in] mode   触发模式（框架已校验 caps，保证此模式受支持）
+     * @param[in] cb     框架层 ISR 入口（BSP 可在硬件 ISR 中直接调用 hal_gpio_isr，
+     *                    无需使用此参数；保留供非 EXTI 架构使用）
+     * @param[in] arg    传递给 hal_gpio_isr 的参数（同 ctrl）
+     * @return OM_OK 成功，其他值表示硬件配置失败
+     *
+     * @note 仅线程上下文调用
+     * @note 调用前用户应已通过 pin_configure 将引脚设为输入模式
+     */
+    OmRet (*pin_attach_irq)(GpioController *ctrl, uint8_t offset,
+                            GpioIrqMode mode, void (*cb)(void *), void *arg);
+
+    /**
+     * @brief  使能或禁用引脚硬件中断
+     *
+     * @details 控制 NVIC 中对应中断通道的使能状态。
+     *          enable=true 前应已完成 pin_attach_irq 配置。
+     *
+     * @param[in] ctrl   当前控制器
+     * @param[in] offset 引脚偏移 [0, pin_count)
+     * @param[in] enable true 使能 NVIC 中断，false 禁用
+     * @return OM_OK 成功
+     *
+     * @note 仅线程上下文调用
+     */
+    OmRet (*pin_irq_enable)(GpioController *ctrl, uint8_t offset, bool enable);
+
+    /* ===== 端口级（可选，NULL 表示不支持） ===== */
+
+    /**
+     * @brief  掩码写入端口
+     *
+     * @details 仅更新 mask 中为 1 的位：对应位 value=1 置高，value=0 置低。
+     *          mask 为 0 的位不受影响。
+     *
+     * @param[in] ctrl   当前控制器
+     * @param[in] mask   写入掩码（bit n=1 表示更新第 n 个引脚）
+     * @param[in] value  物理电平值（bit n 对应第 n 个引脚的目标电平）
+     * @return OM_OK 成功
+     */
+    OmRet (*port_write_masked)(GpioController *ctrl, uint32_t mask, uint32_t value);
+
+    /**
+     * @brief  原子置位指定引脚
+     * @details 将 pins 中为 1 的位对应的引脚物理电平拉高，其他引脚不变。
+     * @param[in] ctrl  当前控制器
+     * @param[in] pins  目标引脚位掩码
+     * @return OM_OK 成功
+     */
+    OmRet (*port_set_bits)(GpioController *ctrl, uint32_t pins);
+
+    /**
+     * @brief  原子清零指定引脚
+     * @details 将 pins 中为 1 的位对应的引脚物理电平拉低，其他引脚不变。
+     * @param[in] ctrl  当前控制器
+     * @param[in] pins  目标引脚位掩码
+     * @return OM_OK 成功
+     */
+    OmRet (*port_clear_bits)(GpioController *ctrl, uint32_t pins);
+
+    /**
+     * @brief  翻转指定引脚电平
+     * @details 将 pins 中为 1 的位对应的引脚物理电平取反。
+     * @warning 若硬件不支持原子翻转（如 STM32F4 的 ODR RMW），
+     *          调用者需保证不在多上下文中对同一控制器并发此操作。
+     * @param[in] ctrl  当前控制器
+     * @param[in] pins  目标引脚位掩码
+     * @return OM_OK 成功
+     */
+    OmRet (*port_toggle_bits)(GpioController *ctrl, uint32_t pins);
+
+    /**
+     * @brief  读取整个端口物理电平
+     * @param[in] ctrl  当前控制器
+     * @return 端口物理电平值（bit n = 第 n 个引脚的电平，0=低 1=高）
+     */
+    uint32_t (*port_read)(GpioController *ctrl);
+};
+
+/**
+ * @name 引脚解析与校验
+ * @{ */
+
+/**
+ * @brief  从编译时描述符解析运行时引脚句柄
+ * @param[in] spec  编译时引脚描述符，不可为 NULL
+ * @return 运行时引脚句柄；解析失败时 ctrl 为 NULL
+ * @note   通常在初始化阶段调用一次，后续复用返回的 #GpioPin
+ */
+GpioPin gpio_pin_get(const GpioPinSpec *spec);
+
+/**
+ * @brief  检查引脚句柄是否有效
+ * @param[in] pin  待检查的引脚句柄
+ * @return true 有效，false 无效（ctrl 为 NULL）
+ */
+bool gpio_pin_valid(GpioPin pin);
+
+/** @} */
+
+/**
+ * @name 引脚级操作
+ * @{ */
+
+/**
+ * @brief  配置引脚电气属性
+ * @param[in] pin   有效的引脚句柄
+ * @param[in] cfg   配置参数，不可为 NULL
+ * @return OM_OK 成功，其他值见错误码
+ * @note   调用者需保证与同一引脚的 write/read 不并发
+ */
+OmRet gpio_pin_configure(GpioPin pin, const GpioPinConfig *cfg);
+
+/**
+ * @brief  写引脚电平
+ * @param[in] pin    有效的引脚句柄
+ * @param[in] value  0 为低电平，非 0 为高电平
+ * @note   若引脚设置了 #GPIO_FLAG_ACTIVE_LOW，物理电平自动反转
+ * @note   无锁操作，单寄存器写入在硬件层保证原子性
+ */
+void gpio_pin_write(GpioPin pin, uint8_t value);
+
+/**
+ * @brief  读引脚电平
+ * @param[in] pin  有效的引脚句柄
+ * @return 0 低电平，1 高电平
+ * @note   若引脚设置了 #GPIO_FLAG_ACTIVE_LOW，返回值自动反转
+ */
+uint8_t gpio_pin_read(GpioPin pin);
+
+/**
+ * @brief  翻转引脚电平
+ * @param[in] pin  有效的引脚句柄
+ * @note   无锁操作，BSP 层利用硬件原子翻转能力
+ */
+void gpio_pin_toggle(GpioPin pin);
+
+/** @} */
+
+/**
+ * @name 中断管理
+ * @{ */
+
+/**
+ * @brief  注册中断回调
+ * @param[in] pin       有效的引脚句柄
+ * @param[in] mode      中断触发模式
+ * @param[in] callback  回调函数，不可为 NULL；在 ISR 上下文中执行，
+ *                      必须遵守 ISR 约束（不可阻塞、不可耗时）
+ * @param[in] arg       回调函数参数
+ * @return OM_OK 成功，其他值见错误码
+ * @note   此函数仅注册回调，不使能硬件中断。
+ *         需随后调用 gpio_pin_irq_enable() 使能中断。
+ * @note   内部通过关中断保护回调表，防止与 ISR 并发修改
+ */
+OmRet gpio_pin_attach_irq(GpioPin pin, GpioIrqMode mode,
+                           void (*callback)(void *arg), void *arg);
+
+/**
+ * @brief  注销中断回调
+ * @param[in] pin  有效的引脚句柄
+ * @return OM_OK 成功
+ * @note   内部通过关中断保护回调表。
+ *         注销后应同步调用 gpio_pin_irq_enable(pin, false) 禁用硬件中断。
+ */
+OmRet gpio_pin_detach_irq(GpioPin pin);
+
+/**
+ * @brief  使能或禁用引脚硬件中断
+ * @param[in] pin     有效的引脚句柄
+ * @param[in] enable  true 使能，false 禁用
+ * @return OM_OK 成功，其他值见错误码
+ */
+OmRet gpio_pin_irq_enable(GpioPin pin, bool enable);
+
+/** @} */
+
+/**
+ * @name 端口级批量操作
+ * @details 端口级 API 直接操作硬件寄存器，使用**物理电平**语义：
+ *          value 的每一位直接对应引脚的物理电平，不经过 ACTIVE_LOW 反转。
+ *          如需逻辑电平操作，请使用引脚级 API（gpio_pin_write 等）。
+ *
+ *          Zephyr 提供了 gpio_port_set_masked（逻辑）和 _raw 变体（物理），
+ *          当前设计出于简洁性考虑仅提供物理接口，后续可按需扩展。
+ * @{ */
+
+/**
+ * @brief  从控制器名称解析端口句柄
+ * @param[in] controller  控制器名称，如 "gpio0"
+ * @return 端口句柄；解析失败时 ctrl 为 NULL
+ */
+GpioPort gpio_port_get(const char *controller);
+
+/**
+ * @brief  检查端口句柄是否有效
+ * @param[in] port  待检查的端口句柄
+ * @return true 有效，false 无效
+ */
+bool gpio_port_valid(GpioPort port);
+
+/**
+ * @brief  掩码写入端口
+ * @param[in] port   有效的端口句柄
+ * @param[in] mask   写入掩码，仅 mask 为 1 的位被更新
+ * @param[in] value  待写入的值
+ * @return OM_OK 成功，OM_ERROR_PARAM 控制器不支持此操作或参数无效
+ */
+OmRet gpio_port_write_masked(GpioPort port, uint32_t mask, uint32_t value);
+
+/**
+ * @brief  原子置位指定引脚
+ * @param[in] port  有效的端口句柄
+ * @param[in] pins  目标引脚位掩码
+ * @return OM_OK 成功，OM_ERROR_PARAM 控制器不支持此操作或参数无效
+ */
+OmRet gpio_port_set_bits(GpioPort port, uint32_t pins);
+
+/**
+ * @brief  原子清零指定引脚
+ * @param[in] port  有效的端口句柄
+ * @param[in] pins  目标引脚位掩码
+ * @return OM_OK 成功，OM_ERROR_PARAM 控制器不支持此操作或参数无效
+ */
+OmRet gpio_port_clear_bits(GpioPort port, uint32_t pins);
+
+/**
+ * @brief  原子翻转指定引脚
+ * @param[in] port  有效的端口句柄
+ * @param[in] pins  目标引脚位掩码
+ * @return OM_OK 成功，OM_ERROR_PARAM 控制器不支持此操作或参数无效
+ */
+OmRet gpio_port_toggle_bits(GpioPort port, uint32_t pins);
+
+/**
+ * @brief  读取整个端口电平
+ * @param[in] port  有效的端口句柄
+ * @return 端口电平值，每位对应一个引脚；控制器不支持时返回 0
+ */
+uint32_t gpio_port_read(GpioPort port);
+
+/** @} */
+
+/**
+ * @name BSP 侧接口
+ * @{ */
+
+/**
+ * @brief  注册 GPIO 控制器
+ * @param[in] ctrl       控制器结构体指针（BSP 层分配），不可为 NULL
+ * @param[in] name       控制器名称（如 "gpioa"），不可为 NULL
+ * @param[in] pin_count  管理的引脚数量，不可为 0
+ * @param[in] caps       IRQ 能力位图，见 GPIO_CAP_IRQ_xxx
+ * @param[in] ops        硬件操作函数表，不可为 NULL
+ * @param[in] priv       BSP 私有数据指针，可为 NULL
+ * @return OM_OK 成功，OM_ERROR_PARAM 参数无效，OM_ERROR_MEMORY 内存不足
+ * @note   仅在初始化阶段调用
+ */
+OmRet gpio_controller_register(GpioController *ctrl, const char *name,
+                                uint8_t pin_count,
+                                uint32_t caps, const GpioOps *ops, void *priv);
+
+/**
+ * @brief  GPIO ISR 框架入口
+ * @details BSP 层的 EXTI ISR 中调用此函数，框架负责查回调表并调用用户回调。
+ * @param[in] ctrl    发生中断的控制器
+ * @param[in] offset  控制器内引脚偏移
+ */
+void hal_gpio_isr(GpioController *ctrl, uint8_t offset);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __PAL_GPIO_DEV_H__ */

--- a/lib/drivers/include/drivers/peripheral/pal_dev.h
+++ b/lib/drivers/include/drivers/peripheral/pal_dev.h
@@ -12,4 +12,8 @@
 #include "can/pal_can_dev.h"
 #endif
 
+#ifdef __OM_USE_HAL_GPIO
+#include "gpio/pal_gpio_dev.h"
+#endif
+
 #endif // __PAL_DEV_H__

--- a/lib/drivers/src/peripheral/can/hal_can_core.c
+++ b/lib/drivers/src/peripheral/can/hal_can_core.c
@@ -1377,12 +1377,13 @@ OmRet hal_can_register(HalCanHandler *can, char *name, void *handle, uint32_t re
     OmRet ret;
     if (!can || !name || !can->adapterInterface)
         return OM_ERROR_PARAM;
+    can->parent.type = DEVICE_TYPE_CAN;
+    can->parent.handle = handle;
+    can->parent.interface = &can_dev_interface;
+    can->cfg = CAN_DEFUALT_CFG;
     ret = device_register(&can->parent, name, regparams);
     if (ret != OM_OK)
         return ret;
 
-    can->parent.handle = handle;
-    can->parent.interface = &can_dev_interface;
-    can->cfg = CAN_DEFUALT_CFG;
     return ret;
 }

--- a/lib/drivers/src/peripheral/gpio/hal_gpio.c
+++ b/lib/drivers/src/peripheral/gpio/hal_gpio.c
@@ -1,0 +1,309 @@
+/**
+ * @file    hal_gpio.c
+ * @ingroup GPIO
+ * @brief   GPIO 框架层实现
+ * @details
+ * 实现 GPIO PAL 定义的公共 API，包括：
+ * - 控制器注册与 pin 号空间管理
+ * - 引脚句柄解析（GpioPinSpec → GpioPin）
+ * - 引脚级读写/配置/翻转（无锁）
+ * - 中断回调表管理（关中断保护）
+ * - 端口级批量操作
+ *
+ * 设计决策详见 lib/drivers/docs/gpio_design.md。
+ */
+
+#include "drivers/peripheral/gpio/pal_gpio_dev.h"
+#include "osal/osal_core.h"
+#include <string.h>
+
+/**
+ * @brief  GPIO Device 接口占位
+ * @details GPIO 不通过 Device 的 read/write/control 操作，
+ *          所有接口函数均为 NULL，仅用于满足 Device 模型注册要求。
+ */
+static DevInterface gpio_dev_interface = {
+    .init    = NULL,
+    .open    = NULL,
+    .close   = NULL,
+    .read    = NULL,
+    .write   = NULL,
+    .control = NULL,
+};
+
+/* ===== 控制器注册 ===== */
+
+/**
+ * @brief  注册 GPIO 控制器到设备链表
+ * @details 先完整构造 Device（interface/handle/type），再调 device_register。
+ *          分配中断回调表、设置操作函数表和能力位图。
+ *          成功后控制器可通过 device_find() 查找。
+ */
+OmRet gpio_controller_register(GpioController *ctrl, const char *name,
+                                uint8_t pin_count,
+                                uint32_t caps, const GpioOps *ops, void *priv)
+{
+    if (!ctrl || !name || !ops || pin_count == 0)
+        return OM_ERROR_PARAM;
+
+    /* 校验必选 ops（端口级可选，不校验） */
+    if (!ops->pin_configure || !ops->pin_write || !ops->pin_read ||
+        !ops->pin_toggle || !ops->pin_attach_irq || !ops->pin_irq_enable)
+        return OM_ERROR_PARAM;
+
+    GpioIrqHdr *hdrs = (GpioIrqHdr *)osal_malloc(pin_count * sizeof(GpioIrqHdr));
+    if (!hdrs)
+        return OM_ERROR_MEMORY;
+    memset(hdrs, 0, pin_count * sizeof(GpioIrqHdr));
+
+    ctrl->parent.type      = DEVICE_TYPE_GPIO;
+    ctrl->parent.handle    = priv;
+    ctrl->parent.interface = &gpio_dev_interface;
+    ctrl->ops              = ops;
+    ctrl->pin_count        = pin_count;
+    ctrl->caps             = caps;
+    ctrl->priv             = priv;
+    ctrl->irq_hdrs         = hdrs;
+
+    OmRet ret = device_register(&ctrl->parent, (char *)name, 0);
+    if (ret != OM_OK) {
+        ctrl->irq_hdrs = NULL;
+        osal_free(hdrs);
+        return ret;
+    }
+
+    return OM_OK;
+}
+
+/* ===== Pin 句柄解析 ===== */
+
+/**
+ * @brief  通过 device_find() 查找控制器、校验 offset、返回 GpioPin
+ */
+GpioPin gpio_pin_get(const GpioPinSpec *spec)
+{
+    GpioPin invalid = {NULL, 0, 0};
+    if (!spec || !spec->controller)
+        return invalid;
+
+    Device *dev = device_find((char *)spec->controller);
+    if (!dev || dev->type != DEVICE_TYPE_GPIO)
+        return invalid;
+
+    GpioController *ctrl = (GpioController *)dev;
+    if (spec->offset >= ctrl->pin_count)
+        return invalid;
+
+    GpioPin pin = {ctrl, spec->offset, spec->flags};
+    return pin;
+}
+
+/**
+ * @brief  检查 GpioPin 的 ctrl 指针是否非空
+ */
+bool gpio_pin_valid(GpioPin pin)
+{
+    return pin.ctrl != NULL;
+}
+
+/* ===== 引脚级操作（无锁） ===== */
+
+/**
+ * @brief  配置引脚电气属性（逻辑电平语义）
+ * @details init_high 采用逻辑电平（与 gpio_pin_write 一致），
+ *          ACTIVE_LOW 引脚在传递给 BSP 前自动反转物理电平。
+ */
+OmRet gpio_pin_configure(GpioPin pin, const GpioPinConfig *cfg)
+{
+    if (!pin.ctrl || !cfg)
+        return OM_ERROR_PARAM;
+
+    GpioPinConfig actual = *cfg;
+    if ((pin.flags & GPIO_FLAG_ACTIVE_LOW) && cfg->direction == GPIO_DIR_OUTPUT)
+        actual.init_high = !cfg->init_high;
+
+    return pin.ctrl->ops->pin_configure(pin.ctrl, pin.offset, &actual);
+}
+
+/**
+ * @brief  写引脚电平，处理 ACTIVE_LOW 反转
+ */
+void gpio_pin_write(GpioPin pin, uint8_t value)
+{
+    if (!pin.ctrl)
+        return;
+    if (pin.flags & GPIO_FLAG_ACTIVE_LOW)
+        value = !value;
+    pin.ctrl->ops->pin_write(pin.ctrl, pin.offset, value);
+}
+
+/**
+ * @brief  读引脚电平，处理 ACTIVE_LOW 反转
+ */
+uint8_t gpio_pin_read(GpioPin pin)
+{
+    if (!pin.ctrl)
+        return 0;
+    uint8_t value = pin.ctrl->ops->pin_read(pin.ctrl, pin.offset);
+    if (pin.flags & GPIO_FLAG_ACTIVE_LOW)
+        value = !value;
+    return value;
+}
+
+/**
+ * @brief  委托 BSP ops 翻转引脚电平
+ */
+void gpio_pin_toggle(GpioPin pin)
+{
+    if (!pin.ctrl)
+        return;
+    pin.ctrl->ops->pin_toggle(pin.ctrl, pin.offset);
+}
+
+/* ===== 中断管理（仅 IRQ 回调表保护） ===== */
+
+/**
+ * @brief  校验 caps → 关中断保护回调表 → 委托 BSP ops 注册中断
+ * @details 先检查控制器是否支持请求的触发模式（caps 位图），
+ *          再关中断保护回调表（赋值仅几条指令，窗口极短）。
+ */
+OmRet gpio_pin_attach_irq(GpioPin pin, GpioIrqMode mode,
+                           void (*callback)(void *arg), void *arg)
+{
+    if (!pin.ctrl || !callback)
+        return OM_ERROR_PARAM;
+
+    if (!(pin.ctrl->caps & (1U << mode)))
+        return OM_ERROR_NOT_SUPPORT;
+
+    OsalIrqIsrState key;
+    osal_irq_lock(&key);
+    pin.ctrl->irq_hdrs[pin.offset].callback = callback;
+    pin.ctrl->irq_hdrs[pin.offset].arg      = arg;
+    pin.ctrl->irq_hdrs[pin.offset].mode     = mode;
+    osal_irq_unlock(key);
+
+    return pin.ctrl->ops->pin_attach_irq(pin.ctrl, pin.offset, mode,
+                                          callback, arg);
+}
+
+/**
+ * @brief  关中断清空回调表项（不操作硬件中断）
+ */
+OmRet gpio_pin_detach_irq(GpioPin pin)
+{
+    if (!pin.ctrl)
+        return OM_ERROR_PARAM;
+
+    OsalIrqIsrState key;
+    osal_irq_lock(&key);
+    pin.ctrl->irq_hdrs[pin.offset].callback = NULL;
+    pin.ctrl->irq_hdrs[pin.offset].arg      = NULL;
+    pin.ctrl->irq_hdrs[pin.offset].mode     = 0;
+    osal_irq_unlock(key);
+
+    return OM_OK;
+}
+
+/**
+ * @brief  委托 BSP ops 使能/禁用硬件中断
+ */
+OmRet gpio_pin_irq_enable(GpioPin pin, bool enable)
+{
+    if (!pin.ctrl)
+        return OM_ERROR_PARAM;
+    return pin.ctrl->ops->pin_irq_enable(pin.ctrl, pin.offset, enable);
+}
+
+/* ===== ISR 框架入口（BSP ISR 中调用） ===== */
+
+/**
+ * @brief  查 irq_hdrs 表调用用户回调
+ * @details BSP 层 EXTI ISR 中调用 hal_gpio_isr()，框架负责查表分发。
+ */
+void hal_gpio_isr(GpioController *ctrl, uint8_t offset)
+{
+    if (!ctrl || offset >= ctrl->pin_count)
+        return;
+    if (ctrl->irq_hdrs[offset].callback)
+        ctrl->irq_hdrs[offset].callback(ctrl->irq_hdrs[offset].arg);
+}
+
+/* ===== 端口句柄解析 ===== */
+
+/**
+ * @brief  通过 device_find() 查找控制器，返回 GpioPort
+ */
+GpioPort gpio_port_get(const char *controller)
+{
+    GpioPort invalid = {NULL};
+    if (!controller)
+        return invalid;
+
+    Device *dev = device_find((char *)controller);
+    if (!dev || dev->type != DEVICE_TYPE_GPIO)
+        return invalid;
+
+    GpioPort port = {(GpioController *)dev};
+    return port;
+}
+
+/**
+ * @brief  检查 GpioPort 的 ctrl 指针是否非空
+ */
+bool gpio_port_valid(GpioPort port)
+{
+    return port.ctrl != NULL;
+}
+
+/* ===== 端口级批量操作 ===== */
+
+/**
+ * @brief  委托 BSP ops 掩码写入端口
+ */
+OmRet gpio_port_write_masked(GpioPort port, uint32_t mask, uint32_t value)
+{
+    if (!port.ctrl || !port.ctrl->ops->port_write_masked)
+        return OM_ERROR_PARAM;
+    return port.ctrl->ops->port_write_masked(port.ctrl, mask, value);
+}
+
+/**
+ * @brief  委托 BSP ops 原子置位引脚
+ */
+OmRet gpio_port_set_bits(GpioPort port, uint32_t pins)
+{
+    if (!port.ctrl || !port.ctrl->ops->port_set_bits)
+        return OM_ERROR_PARAM;
+    return port.ctrl->ops->port_set_bits(port.ctrl, pins);
+}
+
+/**
+ * @brief  委托 BSP ops 原子清零引脚
+ */
+OmRet gpio_port_clear_bits(GpioPort port, uint32_t pins)
+{
+    if (!port.ctrl || !port.ctrl->ops->port_clear_bits)
+        return OM_ERROR_PARAM;
+    return port.ctrl->ops->port_clear_bits(port.ctrl, pins);
+}
+
+/**
+ * @brief  委托 BSP ops 原子翻转引脚
+ */
+OmRet gpio_port_toggle_bits(GpioPort port, uint32_t pins)
+{
+    if (!port.ctrl || !port.ctrl->ops->port_toggle_bits)
+        return OM_ERROR_PARAM;
+    return port.ctrl->ops->port_toggle_bits(port.ctrl, pins);
+}
+
+/**
+ * @brief  委托 BSP ops 读取端口电平
+ */
+uint32_t gpio_port_read(GpioPort port)
+{
+    if (!port.ctrl || !port.ctrl->ops->port_read)
+        return 0;
+    return port.ctrl->ops->port_read(port.ctrl);
+}

--- a/lib/drivers/src/peripheral/serial/hal_serial.c
+++ b/lib/drivers/src/peripheral/serial/hal_serial.c
@@ -638,6 +638,7 @@ OmRet serial_register(HalSerial *serial, char *name, void *handle, uint32_t regp
 {
     if (!serial || !name)
         return OM_ERROR_PARAM;
+    serial->parent.type = DEVICE_TYPE_SERIAL;
     serial->parent.handle = handle;
     serial->parent.interface = &serial_interface;
     serial->cfg = SERIAL_DEFAULT_CFG;

--- a/lib/include/core/om_config.h
+++ b/lib/include/core/om_config.h
@@ -7,6 +7,7 @@
 /* 抽象层裁剪 */
 #define OM_USE_HAL_SERIALS
 #define OM_USE_HAL_CAN
+#define OM_USE_HAL_GPIO
 
 /*
  * sync 加速开关（统一入口）：

--- a/platform/bsp/boards/rm-c-board/include/bsp.h
+++ b/platform/bsp/boards/rm-c-board/include/bsp.h
@@ -2,6 +2,7 @@
 #define __BSP_H__
 
 #include "bsp_can.h"
+#include "bsp_gpio.h"
 #include "bsp_dwt.h"
 #include "bsp_serial.h"
 

--- a/platform/bsp/boards/rm-c-board/include/bsp_gpio.h
+++ b/platform/bsp/boards/rm-c-board/include/bsp_gpio.h
@@ -1,0 +1,44 @@
+/**
+ * @file    bsp_gpio.h
+ * @brief   rm-c-board GPIO BSP 配置
+ */
+
+#ifndef __BSP_GPIO_H__
+#define __BSP_GPIO_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "drivers/peripheral/gpio/pal_gpio_dev.h"
+#include "stm32f4xx_hal.h"
+
+#define BSP_GPIO_PORT_COUNT    (9U)
+#define BSP_GPIO_PINS_PER_PORT (16U)
+
+/** 默认 GPIO EXTI 中断优先级（0 最高，15 最低），可在板级配置中覆盖 */
+#ifndef BSP_GPIO_IRQ_PRIORITY
+#define BSP_GPIO_IRQ_PRIORITY  (5U)
+#endif
+
+/** STM32F4 EXTI 仅支持边沿触发 */
+#define BSP_GPIO_IRQ_CAPS      (GPIO_CAP_IRQ_EDGE_RISING  | \
+                                GPIO_CAP_IRQ_EDGE_FALLING | \
+                                GPIO_CAP_IRQ_EDGE_BOTH)
+
+typedef struct BspGpio {
+    GPIO_TypeDef *port;
+    GpioController parent;
+    char *name;
+    uint8_t irq_priority;
+} BspGpio;
+
+extern BspGpio gBspGpio[BSP_GPIO_PORT_COUNT];
+
+void bsp_gpio_register(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BSP_GPIO_H__ */

--- a/platform/bsp/boards/rm-c-board/source/core/bsp_cpu.c
+++ b/platform/bsp/boards/rm-c-board/source/core/bsp_cpu.c
@@ -86,6 +86,7 @@ void om_board_init(void)
     DWT_Init(__OM_CPU_FREQ_MHZ);
     bsp_serial_register();
     bsp_can_register();
+    bsp_gpio_register();
 }
 
 /**

--- a/platform/bsp/boards/rm-c-board/source/peripherals/gpio/bsp_gpio_impl.c
+++ b/platform/bsp/boards/rm-c-board/source/peripherals/gpio/bsp_gpio_impl.c
@@ -1,0 +1,232 @@
+/**
+ * @file    bsp_gpio_impl.c
+ * @brief   rm-c-board GPIO BSP 实现（STM32F407）
+ */
+
+#include "bsp_gpio.h"
+
+/* ===== STM32 EXTI IRQ 通道映射 ===== */
+
+static IRQn_Type bsp_gpio_exti_irqn(uint8_t pin)
+{
+    if (pin <= 4)
+        return (IRQn_Type)(EXTI0_IRQn + pin);
+    if (pin <= 9)
+        return EXTI9_5_IRQn;
+    return EXTI15_10_IRQn;
+}
+
+/** 计算 GPIO 端口在 EXTICR 中的索引（GPIOA=0, GPIOB=1, ...） */
+static uint8_t bsp_gpio_port_index(GPIO_TypeDef *port)
+{
+    return (uint8_t)(((uint32_t)port - (uint32_t)GPIOA) / 0x0400U);
+}
+
+/* ===== GpioOps 实现 ===== */
+
+static OmRet bsp_gpio_pin_configure(GpioController *ctrl, uint8_t offset,
+                                     const GpioPinConfig *cfg)
+{
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+    GPIO_InitTypeDef init = {0};
+
+    init.Pin = (uint16_t)(1U << offset);
+
+    /* 方向 + 驱动模式 */
+    if (cfg->direction == GPIO_DIR_OUTPUT) {
+        init.Mode = (cfg->drive == GPIO_DRIVE_OPEN_DRAIN)
+                        ? GPIO_MODE_OUTPUT_OD
+                        : GPIO_MODE_OUTPUT_PP;
+        init.Speed = (cfg->speed == GPIO_SPEED_HIGH)    ? GPIO_SPEED_FREQ_VERY_HIGH
+                   : (cfg->speed == GPIO_SPEED_MEDIUM) ? GPIO_SPEED_FREQ_MEDIUM
+                                                       : GPIO_SPEED_FREQ_LOW;
+        if (cfg->init_high)
+            HAL_GPIO_WritePin(bsp->port, init.Pin, GPIO_PIN_SET);
+        else
+            HAL_GPIO_WritePin(bsp->port, init.Pin, GPIO_PIN_RESET);
+    } else {
+        init.Mode = GPIO_MODE_INPUT;
+    }
+
+    /* 上下拉 */
+    init.Pull = (cfg->pull == GPIO_PULL_UP)  ? GPIO_PULLUP
+              : (cfg->pull == GPIO_PULL_DOWN) ? GPIO_PULLDOWN
+                                              : GPIO_NOPULL;
+
+    HAL_GPIO_Init(bsp->port, &init);
+    return OM_OK;
+}
+
+static void bsp_gpio_pin_write(GpioController *ctrl, uint8_t offset,
+                                uint8_t value)
+{
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+    HAL_GPIO_WritePin(bsp->port, (uint16_t)(1U << offset),
+                      value ? GPIO_PIN_SET : GPIO_PIN_RESET);
+}
+
+static uint8_t bsp_gpio_pin_read(GpioController *ctrl, uint8_t offset)
+{
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+    return (HAL_GPIO_ReadPin(bsp->port, (uint16_t)(1U << offset)) == GPIO_PIN_SET)
+               ? 1 : 0;
+}
+
+static void bsp_gpio_pin_toggle(GpioController *ctrl, uint8_t offset)
+{
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+    HAL_GPIO_TogglePin(bsp->port, (uint16_t)(1U << offset));
+}
+
+/**
+ * @brief  配置 EXTI 路由和 NVIC（不调用 HAL_GPIO_Init，不修改电气配置）
+ * @details 仅操作 EXTI 相关寄存器（EXTICR/RTSR/FTSR/IMR），
+ *          保留用户通过 gpio_pin_configure 设置的 pull 和 mode。
+ */
+static OmRet bsp_gpio_pin_attach_irq(GpioController *ctrl, uint8_t offset,
+                                      GpioIrqMode mode,
+                                      void (*cb)(void *), void *arg)
+{
+    (void)cb;
+    (void)arg;
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+
+    /* 配置 SYSCFG EXTICR：将 EXTI 线路由到当前端口 */
+    __HAL_RCC_SYSCFG_CLK_ENABLE();
+    volatile uint32_t *exticr = &SYSCFG->EXTICR[offset / 4];
+    uint32_t shift = (offset % 4) * 4;
+    uint32_t port_val = bsp_gpio_port_index(bsp->port);
+    *exticr = (*exticr & ~(0xFU << shift)) | (port_val << shift);
+
+    /* 配置 EXTI 边沿触发（不触碰 PUPDR/MODER） */
+    uint32_t bitmask = 1U << offset;
+    switch (mode) {
+    case GPIO_IRQ_EDGE_RISING:
+        EXTI->RTSR |= bitmask;
+        EXTI->FTSR &= ~bitmask;
+        break;
+    case GPIO_IRQ_EDGE_FALLING:
+        EXTI->FTSR |= bitmask;
+        EXTI->RTSR &= ~bitmask;
+        break;
+    case GPIO_IRQ_EDGE_BOTH:
+        EXTI->RTSR |= bitmask;
+        EXTI->FTSR |= bitmask;
+        break;
+    default:
+        return OM_ERROR_NOT_SUPPORT;
+    }
+
+    /* 使能 EXTI 中断掩码 */
+    EXTI->IMR |= bitmask;
+
+    /* 配置 NVIC 优先级（不使能，由 irq_enable 控制） */
+    IRQn_Type irqn = bsp_gpio_exti_irqn(offset);
+    HAL_NVIC_SetPriority(irqn, bsp->irq_priority, 0);
+
+    return OM_OK;
+}
+
+static OmRet bsp_gpio_pin_irq_enable(GpioController *ctrl, uint8_t offset,
+                                      bool enable)
+{
+    (void)ctrl;
+    IRQn_Type irqn = bsp_gpio_exti_irqn(offset);
+    if (enable)
+        HAL_NVIC_EnableIRQ(irqn);
+    else
+        HAL_NVIC_DisableIRQ(irqn);
+    return OM_OK;
+}
+
+/* ===== 端口级操作（直接寄存器） ===== */
+
+static OmRet bsp_gpio_port_write_masked(GpioController *ctrl, uint32_t mask,
+                                         uint32_t value)
+{
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+    bsp->port->BSRR = ((~value & mask) << 16) | (value & mask);
+    return OM_OK;
+}
+
+static OmRet bsp_gpio_port_set_bits(GpioController *ctrl, uint32_t pins)
+{
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+    bsp->port->BSRR = pins;
+    return OM_OK;
+}
+
+static OmRet bsp_gpio_port_clear_bits(GpioController *ctrl, uint32_t pins)
+{
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+    bsp->port->BSRR = pins << 16;
+    return OM_OK;
+}
+
+static OmRet bsp_gpio_port_toggle_bits(GpioController *ctrl, uint32_t pins)
+{
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+    bsp->port->ODR ^= pins;
+    return OM_OK;
+}
+
+static uint32_t bsp_gpio_port_read(GpioController *ctrl)
+{
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+    return bsp->port->IDR;
+}
+
+/* ===== GpioOps 实例 ===== */
+
+static const GpioOps gGpioOps = {
+    .pin_configure  = bsp_gpio_pin_configure,
+    .pin_write      = bsp_gpio_pin_write,
+    .pin_read       = bsp_gpio_pin_read,
+    .pin_toggle     = bsp_gpio_pin_toggle,
+    .pin_attach_irq = bsp_gpio_pin_attach_irq,
+    .pin_irq_enable = bsp_gpio_pin_irq_enable,
+    .port_write_masked = bsp_gpio_port_write_masked,
+    .port_set_bits     = bsp_gpio_port_set_bits,
+    .port_clear_bits   = bsp_gpio_port_clear_bits,
+    .port_toggle_bits  = bsp_gpio_port_toggle_bits,
+    .port_read         = bsp_gpio_port_read,
+};
+
+/* ===== BSP 实例数组 ===== */
+
+BspGpio gBspGpio[BSP_GPIO_PORT_COUNT] = {
+    {GPIOA, {0}, "gpioa", BSP_GPIO_IRQ_PRIORITY},
+    {GPIOB, {0}, "gpiob", BSP_GPIO_IRQ_PRIORITY},
+    {GPIOC, {0}, "gpioc", BSP_GPIO_IRQ_PRIORITY},
+    {GPIOD, {0}, "gpiod", BSP_GPIO_IRQ_PRIORITY},
+    {GPIOE, {0}, "gpioe", BSP_GPIO_IRQ_PRIORITY},
+    {GPIOF, {0}, "gpiof", BSP_GPIO_IRQ_PRIORITY},
+    {GPIOG, {0}, "gpiog", BSP_GPIO_IRQ_PRIORITY},
+    {GPIOH, {0}, "gpioh", BSP_GPIO_IRQ_PRIORITY},
+    {GPIOI, {0}, "gpioi", BSP_GPIO_IRQ_PRIORITY},
+};
+
+/* ===== 注册入口 ===== */
+
+void bsp_gpio_register(void)
+{
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+    __HAL_RCC_GPIOC_CLK_ENABLE();
+    __HAL_RCC_GPIOD_CLK_ENABLE();
+    __HAL_RCC_GPIOE_CLK_ENABLE();
+    __HAL_RCC_GPIOF_CLK_ENABLE();
+    __HAL_RCC_GPIOG_CLK_ENABLE();
+    __HAL_RCC_GPIOH_CLK_ENABLE();
+    __HAL_RCC_GPIOI_CLK_ENABLE();
+
+    for (uint8_t i = 0; i < BSP_GPIO_PORT_COUNT; i++) {
+        gpio_controller_register(
+            &gBspGpio[i].parent,
+            gBspGpio[i].name,
+            BSP_GPIO_PINS_PER_PORT,
+            BSP_GPIO_IRQ_CAPS,
+            &gGpioOps,
+            &gBspGpio[i]);
+    }
+}

--- a/platform/bsp/boards/rm-c-board/source/peripherals/gpio/bsp_gpio_it.c
+++ b/platform/bsp/boards/rm-c-board/source/peripherals/gpio/bsp_gpio_it.c
@@ -1,0 +1,78 @@
+/**
+ * @file    bsp_gpio_it.c
+ * @brief   rm-c-board GPIO EXTI ISR 覆盖（override_sources）
+ */
+
+#include "bsp_gpio.h"
+
+/* ===== EXTI 端口路由（通过 SYSCFG EXTICR 确定） ===== */
+
+static int bsp_gpio_exti_port_index(uint8_t exti_line)
+{
+    volatile uint32_t *exticr = &SYSCFG->EXTICR[exti_line / 4];
+    uint32_t shift = (exti_line % 4) * 4;
+    return (int)((*exticr >> shift) & 0xF);
+}
+
+static void bsp_gpio_dispatch_exti(uint8_t pin_num)
+{
+    int port_idx = bsp_gpio_exti_port_index(pin_num);
+    if (port_idx >= 0 && port_idx < BSP_GPIO_PORT_COUNT)
+        hal_gpio_isr(&gBspGpio[port_idx].parent, pin_num);
+}
+
+/* ===== EXTI0 ~ EXTI4（单引脚 ISR） ===== */
+
+void EXTI0_IRQHandler(void)
+{
+    __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_0);
+    bsp_gpio_dispatch_exti(0);
+}
+
+void EXTI1_IRQHandler(void)
+{
+    __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_1);
+    bsp_gpio_dispatch_exti(1);
+}
+
+void EXTI2_IRQHandler(void)
+{
+    __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_2);
+    bsp_gpio_dispatch_exti(2);
+}
+
+void EXTI3_IRQHandler(void)
+{
+    __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_3);
+    bsp_gpio_dispatch_exti(3);
+}
+
+void EXTI4_IRQHandler(void)
+{
+    __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_4);
+    bsp_gpio_dispatch_exti(4);
+}
+
+/* ===== EXTI9_5 / EXTI15_10（共享 ISR） ===== */
+
+void EXTI9_5_IRQHandler(void)
+{
+    for (uint8_t pin = 5; pin <= 9; pin++) {
+        uint32_t bitmask = 1U << pin;
+        if (__HAL_GPIO_EXTI_GET_IT(bitmask)) {
+            __HAL_GPIO_EXTI_CLEAR_IT(bitmask);
+            bsp_gpio_dispatch_exti(pin);
+        }
+    }
+}
+
+void EXTI15_10_IRQHandler(void)
+{
+    for (uint8_t pin = 10; pin <= 15; pin++) {
+        uint32_t bitmask = 1U << pin;
+        if (__HAL_GPIO_EXTI_GET_IT(bitmask)) {
+            __HAL_GPIO_EXTI_CLEAR_IT(bitmask);
+            bsp_gpio_dispatch_exti(pin);
+        }
+    }
+}

--- a/platform/bsp/data/boards/rm-c-board.lua
+++ b/platform/bsp/data/boards/rm-c-board.lua
@@ -28,6 +28,7 @@ local board = {
         "boards/rm-c-board/source/core/bsp_cpu.c",
         "boards/rm-c-board/source/core/bsp_dwt.c",
         "boards/rm-c-board/source/peripherals/can/bsp_can_impl.c",
+        "boards/rm-c-board/source/peripherals/gpio/bsp_gpio_impl.c",
         "boards/rm-c-board/source/peripherals/serial/bsp_serial_impl.c",
         "boards/rm-c-board/source/peripherals/serial/bsp_serial_init.c",
         "boards/rm-c-board/source/port/om_port_hw.c",
@@ -36,6 +37,7 @@ local board = {
         -- 这些文件用于覆盖启动文件中的 weak ISR，必须直连最终 binary。
         "boards/rm-c-board/source/peripherals/can/bsp_can_it.c",
         "boards/rm-c-board/source/peripherals/serial/serial_it.c",
+        "boards/rm-c-board/source/peripherals/gpio/bsp_gpio_it.c",
     },
     osal = {
         freertos = "boards/rm-c-board/osal/freertos",


### PR DESCRIPTION
## Summary

- 新增 `DeviceType` 设备类型标识，用于 `device_find` 后的类型安全校验，同步更新 CAN/Serial 注册
- 实现 GPIO PAL 框架层：`GpioPinSpec`+`GpioPin` 双类型标识、引脚级读写/配置/翻转、ACTIVE_LOW 逻辑电平自动反转、IRQ 能力位图校验、关中断保护回调表、端口级批量操作
- 实现 rm-c-board BSP 适配：STM32F407 GPIOA-GPIOI 控制器注册、GpioOps 函数表、直接 EXTI 寄存器配置（不修改电气属性）、EXTI ISR 分发

## Design

14 项设计决策详见 `lib/drivers/docs/gpio_design.md`，核心要点：

| 决策 | 选择 | 参考 |
|------|------|------|
| 职责边界 | GPIO I/O + 电气配置，不含引脚复用 | RT-Thread PIN |
| 架构集成 | 内部 Device 注册 + 专用 API | RT-Thread PIN |
| 引脚标识 | GpioPinSpec + GpioPin 双类型 | Linux gpiod |
| 中断模型 | 直接 ISR 回调 | Zephyr / RT-Thread |
| 线程安全 | 仅 IRQ 回调表关中断保护 | RT-Thread / Zephyr |
| BSP attach_irq | 仅配置 EXTI/NVIC，不调用 HAL_GPIO_Init | — |

## Test plan

- [x] armclang 编译通过（`xmake f --board=rm-c-board --os=freertos --toolchain=armclang -m debug && xmake`）
- [x] 三轮自查完成（安全隐患、功能缺陷、语义混淆），所有发现已修复
- [x] BSP 实现对照 GpioOps 接口契约逐项验证
- [ ] 硬件验证（LED/按键/中断）