### PR TITLE
refactor(async): unify workqueue concurrency to pure irq_lock (#37)

### DIFF
--- a/lib/async/docs/workqueue.md
+++ b/lib/async/docs/workqueue.md
@@ -12,50 +12,41 @@ Workqueue（工作队列）是一个**中断安全的延迟工作调度器**，�
 | **去重**    | 同一 Work 重复入队返回 BUSY，防止意外堆积                                      |
 | **可取消**   | 支持从 pending 队列中 O(1) 取消未执行的工作项                                  |
 | **简单**    | 仅关中断保护，无 CAS 自旋、互斥量、优先级继承等复杂机制                                  |
-| **极小临界区** | irq\_lock 内仅做指针赋值操作，关中断时间可忽略                                    |
+| **极小临界区** | irq_lock 内仅做指针赋值和 flags 判断操作，关中断时间可忽略                            |
 
 ## 并发模型
 
-### 核心原理：开关中断 + 分层同步策略
+### 核心原理：开关中断
 
 单核 + RTOS 下，所有并发竞争源自 ISR/线程 打断线程。
 
-- **irq\_lock 内**：临界区提供互斥 + 编译器屏障，flags 使用普通 volatile 读写，无需原子操作
-- **irq\_lock 外**：使用原子操作建立 happens-before（enqueue CAS、worker STORE\_REL、work\_is\_busy LOAD\_ACQ）
+- **irq_lock 内**：临界区提供互斥 + 编译器屏障，flags 和链表使用普通 volatile 读写
+- **irq_lock 外**：单核上 volatile 读写天然可见（无 store buffer），无需额外内存屏障
 
 ### 保护范围
 
 | 共享状态                      | 保护方式                                                                      |
 | ------------------------- | ------------------------------------------------------------------------- |
 | `Workqueue.pending` 链表    | `osal_irq_lock`                                                           |
-| `Work.flags`（irq\_lock 内） | 临界区互斥，普通 volatile 读写                                                      |
-| `Work.flags`（irq\_lock 外） | `CAS_RLX`（enqueue 去重）、`STORE_REL`（worker 发布完成）、`LOAD_ACQ`（work\_is\_busy） |
-| `Workqueue.state`         | `CAS_AR`（生命周期切换）、`LOAD_ACQ`（状态检查）                                         |
+| `Work.flags`              | `osal_irq_lock`（所有检查和修改均在临界区内）                                             |
+| `Workqueue.state`         | `osal_irq_lock`（start/stop 状态切换）、volatile 读取（enqueue/flush/worker 状态检查） |
 
 ## 标志位状态机
 
 ```
 Work.flags:
-                         ┌───────────────────────┐
-                         │                       │
-                         ▼                       │
-┌──────┐  enqueue   ┌─────────┐   worker    ┌─────────┐   func结束   ┌──────┐
+┌──────┐  enqueue    ┌─────────┐   worker    ┌─────────┐   func结束   ┌──────┐
 │ IDLE │ ────────►  │ PENDING │ ──────────► │ RUNNING │ ──────────►  │ IDLE │
-└──────┘   CAS      └─────────┘   flags=    └─────────┘   STORE_REL  └──────┘
-   ▲                    │        RUNNING                     ▲
-   │                    │ cancel                             │
-   │                    ▼                                    │
-   │              ┌──────────────┐                           │
-   │              │ PENDING|     │                           │
-   │              │ CANCELLED    │─── worker 检测到 ──────────┘
-   │              └──────┬───────┘    跳过 func, STORE_REL IDLE
-   │                     │
-   └── cancel list_del ──┘
+└──────┘  irq_lock  └────┬────┘   irq_lock  └─────────┘              └──────┘
+     ▲                    │
+     │           cancel   │
+     └────────────────────┘
+              irq_lock
 
 Workqueue.state:
   ┌────────┐  init    ┌──────┐  start    ┌─────────┐  stop     ┌──────────┐
   │ UNINIT │ ──────►  │ IDLE │ ────────► │ RUNNING │ ────────► │ STOPPING │
-  └────────┘          └──────┘   CAS     └─────────┘   CAS      └─────┬────┘
+  └────────┘          └──────┘  irq_lock  └─────────┘  irq_lock  └─────┬────┘
        ▲                 ▲                                              │
        │                 │              drain完成                       │
        │                 └──────────────────────────────────────────────┘
@@ -71,7 +62,7 @@ Workqueue.state:
 | `workqueue_stop(wq)`          | -        | 排空 + 等待 worker 退出    |
 | `workqueue_enqueue(wq, work)` | ✓        | 入队，去重（重复返回 BUSY）     |
 | `workqueue_cancel(work)`      | ✓        | 取消 pending 工作项       |
-| `workqueue_flush(wq)`         | ✗ (阻塞调用) | 排空所有 pending 工作并等待   |
+| `workqueue_flush(wq)`         | ✗ (阻塞调用) | barrier work 方案排空并等待 |
 | `workqueue_is_empty(wq)`      | ✓        | 查询队列是否为空             |
 | `work_is_busy(work)`          | ✓        | 查询工作项是否忙碌            |
 
@@ -84,4 +75,3 @@ Workqueue.state:
 3. 保持现有 API 不变，cancel/flush 语义通过多 worker 协调自然扩展
 
 **暂不实现的原因**：单核 Cortex-M 上多 worker 无并行收益，仅增加栈内存消耗和上下文切换开销。待多核场景或明确并发瓶颈时再引入。
-

--- a/lib/async/include/async/workqueue.h
+++ b/lib/async/include/async/workqueue.h
@@ -29,19 +29,19 @@
  *
  * 双向链表支持两项关键操作：
  * - **O(1) 队头出队**: worker 通过 list_first_entry 获取下一个工作项
- * - **O(1) 任意位置删除**: cancel 通过 list_node_is_linked + list_del_init 从队列中间移除
+ * - **O(1) 任意位置删除**: cancel 通过 list_del 从队列中间移除
  *
  * ## Worker Ownership 协议
  *
- * Enqueue、Worker、Cancel 三方通过 irq_lock + flags 标志位协调对 Work 的"所有权"：
+ * Enqueue、Worker、Cancel 三方通过 irq_lock + flags 协调对 Work 的"所有权"：
  *
  * ```
- * enqueue:  [CAS: IDLE→PENDING]  →  [irq_lock: list_add_tail]  →  [sem_post]
- * worker:   [sem_wait]  →  [irq_lock: list_del + flags=PENDING→RUNNING]  →  [执行 func]
- * cancel:   [irq_lock: 检查 flags + 设置 CANCELLED + 可能 list_del]
+ * enqueue:  [irq_lock: flags 检查 + list_add_tail]  →  [sem_post]
+ * worker:   [sem_wait]  →  [irq_lock: list_del + flags=RUNNING]  →  [执行 func]  →  [flags=IDLE]
+ * cancel:   [irq_lock: 检查 flags + list_del + flags=IDLE]
  * ```
  *
- * **关键不变量**: list_del_init 和 flags 状态转换必须在同一 irq_lock 临界区内完成。
+ * **关键不变量**: flags 检查、链表操作和 flags 状态转换均在同一 irq_lock 临界区内完成。
  * 这确保 cancel 看到 PENDING 时节点必定在链表中，看到 RUNNING 时 worker 已认领。
  *
  * ## 生命周期状态机
@@ -69,21 +69,22 @@ extern "C" {
 #include "osal/osal_core.h"
 #include "osal/osal_sem.h"
 #include "osal/osal_thread.h"
-#include "atomic/atomic_simple.h"
+#include "sync/completion.h"
 
 /* --------------------------------------------------------------------------
- * Work 标志位（内部使用）
+ * Work 标志位
+ *
+ * 被 work_is_busy() 等内联函数使用，必须暴露在公共头文件中。
+ * 所有 flags 修改均在 irq_lock 临界区内完成，调用者不应直接写 flags。
  *
  * 状态迁移规则：
- *   IDLE ──[enqueue CAS]──→ PENDING ──[worker]──→ RUNNING ──[func 结束]──→ IDLE
- *   PENDING ──[cancel]──→ PENDING | CANCELLED ──[cancel list_del]──→ IDLE
- *   PENDING ──[cancel]──→ PENDING | CANCELLED ──[worker 检测到, 跳过]──→ RUNNING → IDLE
+ *   IDLE ──[enqueue irq_lock]──→ PENDING ──[worker irq_lock]──→ RUNNING ──[func 结束]──→ IDLE
+ *   PENDING ──[cancel irq_lock]──→ IDLE
  * -------------------------------------------------------------------------- */
 
 #define WORK_FLAG_IDLE      ((uint32_t)0x00U) /**< 空闲，可被入队 */
 #define WORK_FLAG_PENDING   ((uint32_t)0x01U) /**< 在 pending 队列中等待 */
-#define WORK_FLAG_CANCELLED ((uint32_t)0x02U) /**< 取消请求已发出 */
-#define WORK_FLAG_RUNNING   ((uint32_t)0x04U) /**< worker 正在执行 */
+#define WORK_FLAG_RUNNING   ((uint32_t)0x02U) /**< worker 正在执行 */
 
 /* --------------------------------------------------------------------------
  * Workqueue 生命周期状态
@@ -133,10 +134,10 @@ typedef void (*WorkFunc)(Work *work);
  * - flags: 状态标志位（WORK_FLAG_*），在 irq_lock 内管理
  */
 struct Work {
-    ListHead      node;  /**< 侵入式链表节点，挂在 pending 队列 */
-    WorkFunc      func;  /**< 工作处理函数 */
-    void         *data;  /**< 用户上下文 */
-    OmAtomicUint  flags; /**< 状态标志位 (WORK_FLAG_*) */
+    ListHead        node;  /**< 侵入式链表节点，挂在 pending 队列 */
+    WorkFunc        func;  /**< 工作处理函数 */
+    void           *data;  /**< 用户上下文 */
+    volatile uint32_t flags; /**< 状态标志位 (WORK_FLAG_*) */
 };
 
 /**
@@ -157,16 +158,16 @@ typedef struct WorkqueueConfig {
  *   Workqueue wq;
  *   workqueue_init(&wq, &cfg);
  */
-struct Workqueue {
+typedef struct Workqueue {
     ListHead     pending;      /**< pending 工作项双向链表哨兵 */
     OsalSem     *sem;          /**< 工作到达信号量（计数型，最大1） */
     OsalThread  *thread;       /**< worker 线程句柄 */
     Completion   done;         /**< worker 退出同步原语 */
-    OmAtomicInt  state;        /**< 生命周期状态 (WORKQUEUE_STATE_*) */
+    volatile int state;        /**< 生命周期状态 (WORKQUEUE_STATE_*) */
     uint32_t     stack_depth;  /**< worker 线程栈大小（字节） */
     uint32_t     priority;     /**< worker 线程优先级 */
     const char  *name;         /**< 调试名称 */
-};
+} Workqueue;
 
 /* --------------------------------------------------------------------------
  * API
@@ -274,8 +275,8 @@ OmRet workqueue_cancel(Work *work);
  * 同步等待——返回时，所有当前 pending 的工作项已执行完毕（或被取消）。
  * 工作队列必须处于 RUNNING 状态。
  *
- * 实现通过两次 sem_post/sem_wait 握手确保 worker 已完成至少一次完整的
- * 排空循环。
+ * 实现采用 barrier work 方案：向队列尾部插入一个 barrier 工作项，
+ * FIFO 语义保证 barrier 执行时之前的所有 work 已完成。
  *
  * @param wq  正在运行的工作队列。
  * @return    OM_OK 成功，OM_ERROR 工作队列未在运行，OM_ERROR_PARAM 参数为 NULL。
@@ -319,7 +320,7 @@ static inline void work_init(Work *work, WorkFunc func, void *data)
     INIT_LIST_HEAD(&work->node);
     work->func = func;
     work->data = data;
-    OM_STORE_RLX(&work->flags, WORK_FLAG_IDLE);
+    work->flags = WORK_FLAG_IDLE;
 }
 
 /**
@@ -330,8 +331,7 @@ static inline void work_init(Work *work, WorkFunc func, void *data)
  */
 static inline bool work_is_busy(const Work *work)
 {
-    uint32_t f = OM_LOAD_ACQ(&work->flags);
-    return (f & (WORK_FLAG_PENDING | WORK_FLAG_RUNNING)) != 0U;
+    return (work->flags & (WORK_FLAG_PENDING | WORK_FLAG_RUNNING)) != 0U;
 }
 
 #ifdef __cplusplus

--- a/lib/async/src/workqueue.c
+++ b/lib/async/src/workqueue.c
@@ -21,30 +21,30 @@
  * ```
  *   Workqueue.pending → ListHead (双向循环链表哨兵)
  *   Work.node          → ListHead (嵌入 Work 的节点)
- *   Work.flags         → OmAtomicUint (PENDING | CANCELLED | RUNNING 状态位)
+ *   Work.flags         → volatile uint32_t (PENDING | RUNNING 状态位)
  * ```
  *
  * pending 队列采用双向链表，支持：
- *   - **O(1) 队头出队**: worker 通过 list_first_entry + list_del_init 认领工作
- *   - **O(1) 任意位置删除**: cancel 通过 list_node_is_linked + list_del_init 从队列中间移除
+ *   - **O(1) 队头出队**: worker 通过 list_first_entry + list_del 认领工作
+ *   - **O(1) 任意位置删除**: cancel 通过 list_del 从队列中间移除
  *
  * ## Worker Claim 协议（核心并发合同）
  *
- * Enqueue、Worker、Cancel 三方通过 irq_lock + flags 原子操作协调对 Work 的"所有权"：
+ * Enqueue、Worker、Cancel 三方通过 irq_lock + volatile flags 协调对 Work 的"所有权"：
  *
  * ```
- * enqueue:  [CAS: IDLE→PENDING]  →  [irq_lock: list_add_tail]  →  [sem_post]
- * worker:   [sem_wait]  →  [irq_lock: list_del_init + flags=PENDING→RUNNING]  →  [执行 func]
- * cancel:   [irq_lock: 检查 flags + 设置 CANCELLED + 可能 list_del_init]
+ * enqueue:  [irq_lock: flags 检查 + list_add_tail]  →  [sem_post]
+ * worker:   [sem_wait]  →  [irq_lock: list_del + flags=RUNNING]  →  [执行 func]  →  [flags=IDLE]
+ * cancel:   [irq_lock: 检查 flags + list_del + flags=IDLE]
  * ```
  *
- * **关键不变量**: list_del_init 和 flags 状态转换必须在同一 irq_lock 临界区内完成。
+ * **关键不变量**: flags 检查、链表操作和 flags 状态转换均在同一 irq_lock 临界区内完成。
  * 这确保 cancel 看到 PENDING 时节点必定在链表中，看到 RUNNING 时 worker 已认领。
  *
  * ## 内存序策略
  *
  * - **irq_lock 内**: 临界区提供互斥 + 编译器屏障，flags 使用普通 volatile 读写
- * - **irq_lock 外**: 使用原子操作（enqueue CAS、worker STORE_REL、work_is_busy LOAD_ACQ）
+ * - **irq_lock 外**: 单核上 volatile 读写天然可见（无 store buffer），无需额外内存屏障
  */
 
 #include "async/workqueue.h"
@@ -83,8 +83,7 @@ static void workqueue_worker_entry(void *arg)
 
         /** 2. 循环排空 pending 队列 */
         for (;;) {
-            Work  *w        = NULL;
-            bool   cancelled = false;
+            Work *w = NULL;
 
             /** 2a. 关中断：从链表取出下一个工作项并认领 */
             {
@@ -93,24 +92,8 @@ static void workqueue_worker_entry(void *arg)
 
                 if (!list_empty(&wq->pending)) {
                     w = list_first_entry(&wq->pending, Work, node);
-
-                    /** 从 pending 链表移除并毒化节点。 */
-                    list_del_init(&w->node);
-
-                    /** 认领所有权：PENDING → RUNNING。
-                     *
-                     *  irq_lock 内，cancel 不可能并发修改 flags，
-                     *  直接比较即可检测 cancel 是否设置了 CANCELLED。 */
-                    if (w->flags == WORK_FLAG_PENDING) {
-                        w->flags = WORK_FLAG_RUNNING;
-                        cancelled = false;
-                    } else {
-                        /** flags 已被 cancel 改为 PENDING|CANCELLED。
-                         *  我们已从链表取出（拥有所有权），
-                         *  设置 RUNNING 阻止后续 cancel 竞争。 */
-                        w->flags = WORK_FLAG_RUNNING;
-                        cancelled = true;
-                    }
+                    list_del(&w->node);
+                    w->flags = WORK_FLAG_RUNNING;
                 }
 
                 osal_irq_unlock(k);
@@ -118,26 +101,16 @@ static void workqueue_worker_entry(void *arg)
 
             /** 2b. 无更多工作：检查退出条件 */
             if (!w) {
-                int s = OM_LOAD_ACQ(&wq->state);
-                if (s == WORKQUEUE_STATE_STOPPING) {
-                    /** STOPPING 状态 + 队列已空 → worker 退出 */
+                if (wq->state == WORKQUEUE_STATE_STOPPING) {
                     completion_done(&wq->done);
                     osal_thread_exit();
                 }
-                /** 回到 sem_wait 等待新工作 */
                 break;
             }
 
-            /** 2c. 执行或跳过 */
-            if (cancelled) {
-                /** cancel 已请求取消 → 恢复 IDLE，不执行 func */
-                OM_STORE_REL(&w->flags, WORK_FLAG_IDLE);
-            } else {
-                /** 正常执行工作函数 */
-                w->func(w);
-                /** 执行完毕，恢复 IDLE，允许再次入队 */
-                OM_STORE_REL(&w->flags, WORK_FLAG_IDLE);
-            }
+            /** 2c. 执行工作函数 */
+            w->func(w);
+            w->flags = WORK_FLAG_IDLE;
         }
     }
 }
@@ -159,6 +132,10 @@ static void workqueue_worker_entry(void *arg)
 OmRet workqueue_init(Workqueue *wq, const WorkqueueConfig *cfg)
 {
     if (!wq || !cfg) return OM_ERROR_PARAM;
+    if (!cfg->stack_depth) return OM_ERROR_PARAM;
+
+    /** 防止重复初始化 */
+    if (wq->state != WORKQUEUE_STATE_UNINIT) return OM_ERROR;
 
     /** 初始化 pending 链表为空的哨兵态（自循环） */
     INIT_LIST_HEAD(&wq->pending);
@@ -177,7 +154,7 @@ OmRet workqueue_init(Workqueue *wq, const WorkqueueConfig *cfg)
     }
 
     /** 设置状态为 IDLE */
-    OM_STORE_RLX(&wq->state, (int)WORKQUEUE_STATE_IDLE);
+    wq->state = WORKQUEUE_STATE_IDLE;
     wq->name        = cfg->name ? cfg->name : "wq";
     wq->stack_depth = cfg->stack_depth;
     wq->priority    = cfg->priority;
@@ -199,8 +176,7 @@ OmRet workqueue_deinit(Workqueue *wq)
     if (!wq) return OM_ERROR_PARAM;
 
     /** 必须已 stop */
-    int s = OM_LOAD_RLX(&wq->state);
-    if (s != WORKQUEUE_STATE_IDLE) return OM_ERROR;
+    if (wq->state != WORKQUEUE_STATE_IDLE) return OM_ERROR;
 
     if (wq->sem) {
         osal_sem_delete(wq->sem);
@@ -209,7 +185,7 @@ OmRet workqueue_deinit(Workqueue *wq)
 
     completion_deinit(&wq->done);
 
-    OM_STORE_RLX(&wq->state, (int)WORKQUEUE_STATE_UNINIT);
+    wq->state = WORKQUEUE_STATE_UNINIT;
     wq->name = NULL;
     return OM_OK;
 }
@@ -221,7 +197,7 @@ OmRet workqueue_deinit(Workqueue *wq)
 /**
  * @brief 启动 worker 线程
  *
- * 通过 CAS 将状态从 IDLE 切换到 RUNNING，然后创建 FreeRTOS 任务
+ * 通过 irq_lock 将状态从 IDLE 切换到 RUNNING，然后创建 FreeRTOS 任务
  * 作为 worker 线程。如果线程创建失败，状态回退到 IDLE。
  *
  * @param wq  已初始化的工作队列。
@@ -230,12 +206,18 @@ OmRet workqueue_deinit(Workqueue *wq)
 OmRet workqueue_start(Workqueue *wq)
 {
     if (!wq) return OM_ERROR_PARAM;
-    if (!wq->sem) return OM_ERROR; /** 未初始化或已销毁 */
+    if (!wq->sem) return OM_ERROR;
 
-    /** CAS 原子切换：IDLE → RUNNING */
-    int expected = WORKQUEUE_STATE_IDLE;
-    if (!OM_CAS_AR(&wq->state, &expected, WORKQUEUE_STATE_RUNNING)) {
-        return OM_ERROR; /** 不在 IDLE 状态 */
+    /** irq_lock 内检查并切换状态：IDLE → RUNNING */
+    {
+        OsalIrqIsrState key;
+        osal_irq_lock(&key);
+        if (wq->state != WORKQUEUE_STATE_IDLE) {
+            osal_irq_unlock(key);
+            return OM_ERROR;
+        }
+        wq->state = WORKQUEUE_STATE_RUNNING;
+        osal_irq_unlock(key);
     }
 
     /** 排空上一次循环可能残留的信号量计数 */
@@ -254,7 +236,10 @@ OmRet workqueue_start(Workqueue *wq)
                                        workqueue_worker_entry, wq);
     if (st != OSAL_OK) {
         /** 线程创建失败，状态回退 */
-        OM_STORE_RLX(&wq->state, (int)WORKQUEUE_STATE_IDLE);
+        OsalIrqIsrState key;
+        osal_irq_lock(&key);
+        wq->state = WORKQUEUE_STATE_IDLE;
+        osal_irq_unlock(key);
         return OM_ERROR;
     }
 
@@ -265,20 +250,25 @@ OmRet workqueue_start(Workqueue *wq)
  * @brief 停止 worker 线程
  *
  * 状态从 RUNNING 切换到 STOPPING，唤醒 worker 线程，等待其排空
- * pending 队列并退出。worker 退出后进行防御性清理（理论上队列应为空）。
+ * pending 队列并退出。worker 退出后进行防御性清理。
  *
  * @param wq  正在运行的工作队列。
- * @return    OM_OK 成功，OM_ERROR 状态非法（未在运行），OM_ERROR_PARAM 参数为 NULL。
+ * @return    OM_OK 成功，OM_ERROR 状态非法，OM_ERROR_PARAM 参数为 NULL。
  */
 OmRet workqueue_stop(Workqueue *wq)
 {
     if (!wq) return OM_ERROR_PARAM;
 
-    /** CAS 原子切换：RUNNING → STOPPING */
-    int expected = WORKQUEUE_STATE_RUNNING;
-    if (!OM_CAS_AR(&wq->state, &expected, WORKQUEUE_STATE_STOPPING)) {
-        /** 已停止或未在运行 */
-        return OM_ERROR;
+    /** irq_lock 内检查并切换状态：RUNNING → STOPPING */
+    {
+        OsalIrqIsrState key;
+        osal_irq_lock(&key);
+        if (wq->state != WORKQUEUE_STATE_RUNNING) {
+            osal_irq_unlock(key);
+            return OM_ERROR;
+        }
+        wq->state = WORKQUEUE_STATE_STOPPING;
+        osal_irq_unlock(key);
     }
 
     /** 唤醒 worker 线程，使其开始排空 */
@@ -288,24 +278,22 @@ OmRet workqueue_stop(Workqueue *wq)
     completion_wait(&wq->done, OSAL_WAIT_FOREVER);
     wq->thread = NULL;
 
-    /** 防御性排空：清理可能在 worker 退出与 stop 返回之间入队的工作项。
-     *
-     *  STOPPING 状态下 enqueue 会被拒绝（见 workqueue_enqueue 的状态检查），
-     *  理论上队列应为空，但安全起见，尝试清理所有残留工作项。 */
+    /** 防御性排空：清理残留工作项。
+     *  STOPPING 状态下 enqueue 会被拒绝，理论上队列应为空。 */
     {
         Work            *w, *tmp;
         OsalIrqIsrState  k;
         osal_irq_lock(&k);
         list_for_each_entry_safe(w, tmp, &wq->pending, node)
         {
-            list_del_init(&w->node);
+            list_del(&w->node);
             w->flags = WORK_FLAG_IDLE;
         }
         osal_irq_unlock(k);
     }
 
     /** 状态切换：STOPPING → IDLE */
-    OM_STORE_RLX(&wq->state, (int)WORKQUEUE_STATE_IDLE);
+    wq->state = WORKQUEUE_STATE_IDLE;
 
     return OM_OK;
 }
@@ -313,13 +301,9 @@ OmRet workqueue_stop(Workqueue *wq)
 /* ===================================================================
  * 入队操作（Enqueue）
  *
- * enqueue 分两个阶段：
- *   1. irq_lock 外 CAS(IDLE→PENDING)：原子去重
- *   2. irq_lock 内 list_add_tail：保护链表插入的原子性
- *
- * CAS 在锁外的设计理由：CAS 竞争方（worker 的 flags 修改）在
- * irq_lock 内执行，关中断。单核上两个线程级 enqueue 冲突由 CAS 自身解决。
- * 锁外 CAS 避免了 sem_post 调用时持有 irq_lock（sem_post 可能触发任务切换）。
+ * enqueue 的 flags 检查和链表插入在同一 irq_lock 内完成，
+ * 消除 CAS 与 list_add_tail 之间的 TOCTOU 窗口。
+ * irq_lock 保证 flags 和链表操作的原子性。
  * =================================================================== */
 
 /**
@@ -339,26 +323,23 @@ OmRet workqueue_enqueue(Workqueue *wq, Work *work)
     if (!wq || !work) return OM_ERROR_PARAM;
 
     /** 拒绝：工作队列未在运行 */
-    if (OM_LOAD_ACQ(&wq->state) != WORKQUEUE_STATE_RUNNING) {
+    if (wq->state != WORKQUEUE_STATE_RUNNING) {
         return OM_ERROR;
     }
 
-    /** 去重：原子 CAS 从 IDLE 切换到 PENDING。
-     *
-     *  如果 work 当前是 PENDING 或 RUNNING，CAS 失败 → 返回 BUSY
-     *  (等同于 Linux cmwq 的 WORK_STRUCT_PENDING_BIT 去重机制)。 */
-    {
-        uint32_t expected = WORK_FLAG_IDLE;
-        if (!OM_CAS_RLX(&work->flags, &expected, WORK_FLAG_PENDING)) {
-            return OM_ERROR_BUSY; /** 已在队列中或正在执行 */
-        }
-    }
-
-    /** 关中断：将 work 插入 pending 链表尾部（FIFO 顺序） */
+    /** 关中断：flags 去重检查 + 链表插入在同一临界区内 */
     {
         OsalIrqIsrState key;
         osal_irq_lock(&key);
+
+        if (work->flags != WORK_FLAG_IDLE) {
+            osal_irq_unlock(key);
+            return OM_ERROR_BUSY;
+        }
+
+        work->flags = WORK_FLAG_PENDING;
         list_add_tail(&work->node, &wq->pending);
+
         osal_irq_unlock(key);
     }
 
@@ -371,16 +352,14 @@ OmRet workqueue_enqueue(Workqueue *wq, Work *work)
 /* ===================================================================
  * 取消操作
  *
- * cancel 所有操作（flags 检查、CANCELLED 标记、链表删除）均在 irq_lock
- * 临界区内完成。irq_lock 禁用中断和抢占，flags 和链表操作的原子性
- * 由临界区本身保证，使用普通 volatile 读写即可。
+ * cancel 所有操作（flags 检查、链表删除、flags 恢复）均在 irq_lock
+ * 临界区内完成。irq_lock 禁用中断和抢占，保证 flags 和链表操作的原子性。
  * =================================================================== */
 
 /**
  * @brief 取消一个 pending 工作项
  *
- * 线程安全和 ISR 安全。不从特定 workqueue 上取消，而是通过 Work 自身的
- * flags 和 list node 操作。这意味着调用者无需知道 work 在哪个队列上。
+ * 线程安全和 ISR 安全。调用者无需知道 work 在哪个 workqueue 上。
  *
  * @param work  要取消的工作项。
  * @return      OM_OK 成功取消（work 恢复 IDLE，可重新入队）；
@@ -393,8 +372,6 @@ OmRet workqueue_cancel(Work *work)
     if (!work) return OM_ERROR_PARAM;
 
     OsalIrqIsrState key;
-
-    /** ---- 所有 flags 检查和修改均在 irq_lock 内进行 ---- */
     osal_irq_lock(&key);
 
     uint32_t f = work->flags;
@@ -405,30 +382,16 @@ OmRet workqueue_cancel(Work *work)
         return OM_ERROR_BUSY;
     }
 
-    /** 拒绝：work 不在 pending 状态（可能已执行完毕或从未入队） */
+    /** 拒绝：work 不在 pending 状态 */
     if (!(f & WORK_FLAG_PENDING)) {
         osal_irq_unlock(key);
         return OM_ERROR;
     }
 
-    /** 标记取消意图 */
-    work->flags = f | WORK_FLAG_CANCELLED;
-
-    /** 尝试从 pending 链表移除。
-     *
-     *  因为我们持有 irq_lock，worker 不可能在此期间从链表取走该节点。
-     *  因此在 flags 为 PENDING 的前提下，节点必定仍在链表中。
-     *
-     *  list_del_init 将节点 next/prev 设为 NULL，兼具毒化效果。
-     *  后续 work_init() 会重新 INIT_LIST_HEAD 使节点恢复可用。 */
-    if (list_node_is_linked(&work->node)) {
-        list_del_init(&work->node);
-        /** 成功从链表移除 → 清理所有标志位，work 恢复 IDLE */
-        work->flags = WORK_FLAG_IDLE;
-    }
-    /** 如果节点已不在链表中：worker 已在另一个 irq_lock 临界区中
-     *  将其取出。worker 在检查 flags 时会检测到我们设置的 CANCELLED 位，
-     *  并跳过执行。 */
+    /** 从 pending 链表移除并恢复 IDLE。
+     *  irq_lock 保证 worker 不可能并发取走该节点。 */
+    list_del(&work->node);
+    work->flags = WORK_FLAG_IDLE;
 
     osal_irq_unlock(key);
     return OM_OK;
@@ -437,13 +400,23 @@ OmRet workqueue_cancel(Work *work)
 /* ===================================================================
  * 排空操作（Flush）
  *
- * flush 等待当前 pending 队列中所有工作项执行完毕。
- * 实现原理：通过两次 sem_post/sem_wait 握手确保 worker 已完成至少
- * 一次完整的排空循环。
+ * 参考 Linux 内核 flush_workqueue 的 barrier work 方案：
+ * 向 pending 队列尾部插入一个 barrier work，等待它执行完毕。
+ * FIFO 语义保证 barrier 之前的所有 work 已执行完毕。
  * =================================================================== */
+
+/** barrier work 的回调：通知 flush 调用者 */
+static void flush_barrier_fn(Work *w)
+{
+    Completion *c = (Completion *)w->data;
+    completion_done(c);
+}
 
 /**
  * @brief 排空所有 pending 工作项并同步等待完成
+ *
+ * 向 pending 队列尾部插入一个 barrier work 并阻塞等待其执行。
+ * FIFO 语义保证 barrier 之前的所有 work 已执行完毕（或被取消）。
  *
  * @param wq  正在运行的工作队列。
  * @return    OM_OK 成功，OM_ERROR 状态非法，OM_ERROR_PARAM 参数为 NULL。
@@ -453,22 +426,30 @@ OmRet workqueue_flush(Workqueue *wq)
     if (!wq) return OM_ERROR_PARAM;
 
     /** 工作队列必须处于 RUNNING 状态 */
-    if (OM_LOAD_ACQ(&wq->state) != WORKQUEUE_STATE_RUNNING) {
+    if (wq->state != WORKQUEUE_STATE_RUNNING) {
         return OM_ERROR;
     }
 
-    /** 发送两次信号量并等待 worker 两次消费。
-     *
-     *  第一次信号量触发 worker 排空当前 pending 队列，
-     *  第二次信号量确认 worker 已完成排空并回到了 sem_wait 等待状态。
-     *
-     *  这种双握手确保 worker 至少完成了一次完整的"取出→执行→回到等待"
-     *  循环，因此入队早于 flush 调用的所有 work 已处理完毕。 */
-    osal_sem_post_auto(wq->sem);
-    osal_sem_wait(wq->sem, OSAL_WAIT_FOREVER);
+    /** 初始化 barrier 同步原语 */
+    Completion barrier;
+    OmRet rc = completion_init(&barrier);
+    if (rc != OM_OK) return rc;
 
-    osal_sem_post_auto(wq->sem);
-    osal_sem_wait(wq->sem, OSAL_WAIT_FOREVER);
+    /** 创建并入队 barrier work。
+     *  barrier 排在当前所有 pending work 之后，
+     *  FIFO 语义确保它执行时之前的 work 已全部完成。 */
+    Work bw;
+    work_init(&bw, flush_barrier_fn, &barrier);
+
+    rc = workqueue_enqueue(wq, &bw);
+    if (rc != OM_OK) {
+        completion_deinit(&barrier);
+        return rc;
+    }
+
+    /** 阻塞等待 barrier work 执行完毕 */
+    completion_wait(&barrier, OSAL_WAIT_FOREVER);
+    completion_deinit(&barrier);
 
     return OM_OK;
 }
@@ -486,7 +467,7 @@ OmRet workqueue_flush(Workqueue *wq)
 int workqueue_get_state(const Workqueue *wq)
 {
     if (!wq) return WORKQUEUE_STATE_UNINIT;
-    return OM_LOAD_RLX(&wq->state);
+    return wq->state;
 }
 
 /**

--- a/samples/host/workqueue/data_struct/corelist.h
+++ b/samples/host/workqueue/data_struct/corelist.h
@@ -1,0 +1,23 @@
+/**
+ * @file    corelist.h
+ * @brief   MSVC 兼容的 corelist.h 本地覆盖
+ *
+ * 引入原始 corelist.h 后覆盖 container_of 宏，移除 GCC 语句表达式。
+ * 需 MSVC 2022 17.9+（C11 typeof 支持）。
+ */
+#ifndef __HOST_CORE_LIST_OVERRIDE__
+#define __HOST_CORE_LIST_OVERRIDE__
+
+#include "../../../../lib/data_struct/include/data_struct/corelist.h"
+
+#ifdef _MSC_VER
+/* MSVC: 移除 GCC 语句表达式，使用简化版 container_of */
+#undef container_of
+#define container_of(ptr, type, member) \
+    ((type *)((char *)(ptr) - offsetof(type, member)))
+
+#undef CONTAINER_OF
+#define CONTAINER_OF(ptr, type, member) container_of(ptr, type, member)
+#endif
+
+#endif /* __HOST_CORE_LIST_OVERRIDE__ */

--- a/samples/host/workqueue/host_osal.c
+++ b/samples/host/workqueue/host_osal.c
@@ -1,0 +1,187 @@
+/**
+ * @file    host_osal.c
+ * @brief   Win32 平台 OSAL + Completion 实现（host 测试用）
+ */
+
+#include <windows.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "osal/osal_config.h"
+#include "osal/osal_core.h"
+#include "osal/osal_sem.h"
+#include "osal/osal_thread.h"
+#include "sync/completion.h"
+
+/* ===================================================================
+ * irq_lock — Win32 CriticalSection
+ * =================================================================== */
+
+static CRITICAL_SECTION g_cs;
+static volatile LONG g_cs_inited = 0;
+
+static void ensure_cs(void)
+{
+    if (!g_cs_inited) {
+        InitializeCriticalSection(&g_cs);
+        g_cs_inited = 1;
+    }
+}
+
+int osal_is_in_isr(void) { return 0; }
+
+void osal_irq_lock_task(void)
+{
+    ensure_cs();
+    EnterCriticalSection(&g_cs);
+}
+
+void osal_irq_unlock_task(void) { LeaveCriticalSection(&g_cs); }
+
+OsalIrqIsrState osal_irq_lock_from_isr(void)
+{
+    osal_irq_lock_task();
+    return 0;
+}
+
+void osal_irq_unlock_from_isr(OsalIrqIsrState state)
+{
+    (void)state;
+    osal_irq_unlock_task();
+}
+
+void osal_sleep_ms(uint32_t ms) { Sleep(ms); }
+
+/* ===================================================================
+ * Semaphore — Win32 CreateSemaphore
+ * =================================================================== */
+
+struct OsalSemHandle_s {
+    HANDLE handle;
+};
+
+OsalStatus osal_sem_create(OsalSem **sem, uint32_t max_count, uint32_t init_count)
+{
+    OsalSem *s = (OsalSem *)malloc(sizeof(OsalSem));
+    if (!s) return OSAL_TIMEOUT;
+    s->handle = CreateSemaphoreA(NULL, (LONG)init_count, (LONG)max_count, NULL);
+    if (!s->handle) {
+        free(s);
+        return OSAL_TIMEOUT;
+    }
+    *sem = s;
+    return OSAL_OK;
+}
+
+OsalStatus osal_sem_delete(OsalSem *sem)
+{
+    if (!sem) return OSAL_TIMEOUT;
+    CloseHandle(sem->handle);
+    free(sem);
+    return OSAL_OK;
+}
+
+OsalStatus osal_sem_wait(OsalSem *sem, uint32_t timeout_ms)
+{
+    if (!sem) return OSAL_TIMEOUT;
+    DWORD ms = (timeout_ms == OSAL_WAIT_FOREVER) ? INFINITE : (DWORD)timeout_ms;
+    DWORD r  = WaitForSingleObject(sem->handle, ms);
+    if (r == WAIT_OBJECT_0) return OSAL_OK;
+    return OSAL_TIMEOUT;
+}
+
+OsalStatus osal_sem_post(OsalSem *sem)
+{
+    if (!sem) return OSAL_TIMEOUT;
+    ReleaseSemaphore(sem->handle, 1, NULL);
+    return OSAL_OK;
+}
+
+OsalStatus osal_sem_post_from_isr(OsalSem *sem) { return osal_sem_post(sem); }
+
+/* ===================================================================
+ * Thread — Win32 CreateThread
+ * =================================================================== */
+
+struct OsalThreadHandle_s {
+    HANDLE handle;
+};
+
+typedef struct {
+    OsalThreadEntryFunction entry;
+    void                   *arg;
+} ThreadStartCtx;
+
+static DWORD WINAPI thread_start_wrapper(LPVOID param)
+{
+    ThreadStartCtx *ctx = (ThreadStartCtx *)param;
+    OsalThreadEntryFunction fn = ctx->entry;
+    void *arg = ctx->arg;
+    free(ctx);
+    fn(arg);
+    return 0;
+}
+
+OsalStatus osal_thread_create(OsalThread **thread, const OsalThreadAttr *attr,
+                              OsalThreadEntryFunction entry, void *arg)
+{
+    ThreadStartCtx *ctx = (ThreadStartCtx *)malloc(sizeof(ThreadStartCtx));
+    if (!ctx) return OSAL_TIMEOUT;
+    ctx->entry = entry;
+    ctx->arg   = arg;
+
+    OsalThread *t = (OsalThread *)malloc(sizeof(OsalThread));
+    if (!t) {
+        free(ctx);
+        return OSAL_TIMEOUT;
+    }
+
+    t->handle = CreateThread(NULL, (SIZE_T)attr->stackSize,
+                             thread_start_wrapper, ctx, 0, NULL);
+    if (!t->handle) {
+        free(t);
+        free(ctx);
+        return OSAL_TIMEOUT;
+    }
+
+    *thread = t;
+    return OSAL_OK;
+}
+
+void osal_thread_exit(void) { ExitThread(0); }
+
+/* ===================================================================
+ * Completion — Win32 Event (manual-reset)
+ * =================================================================== */
+
+OmRet completion_init(Completion *c)
+{
+    if (c->_handle) {
+        CloseHandle((HANDLE)c->_handle);
+    }
+    c->_handle = (void *)CreateEventA(NULL, TRUE, FALSE, NULL);
+    if (!c->_handle) return OM_ERROR;
+    return OM_OK;
+}
+
+void completion_deinit(Completion *c)
+{
+    if (c->_handle) {
+        CloseHandle((HANDLE)c->_handle);
+        c->_handle = NULL;
+    }
+}
+
+OmRet completion_wait(Completion *c, size_t timeout_ms)
+{
+    DWORD ms = (timeout_ms == OSAL_WAIT_FOREVER) ? INFINITE : (DWORD)timeout_ms;
+    DWORD r  = WaitForSingleObject((HANDLE)c->_handle, ms);
+    if (r == WAIT_OBJECT_0) return OM_OK;
+    return OM_ERROR_TIMEOUT;
+}
+
+OmRet completion_done(Completion *c)
+{
+    SetEvent((HANDLE)c->_handle);
+    return OM_OK;
+}

--- a/samples/host/workqueue/osal/osal_config.h
+++ b/samples/host/workqueue/osal/osal_config.h
@@ -1,0 +1,6 @@
+#ifndef OM_OSAL_CONFIG_H
+#define OM_OSAL_CONFIG_H
+
+#define OSAL_STACK_WORD_BYTES (4U)
+
+#endif

--- a/samples/host/workqueue/osal/osal_core.h
+++ b/samples/host/workqueue/osal/osal_core.h
@@ -1,0 +1,43 @@
+#ifndef OM_OSAL_CORE_H
+#define OM_OSAL_CORE_H
+
+#include <stdint.h>
+
+typedef int32_t OsalStatus;
+
+#define OSAL_OK         (0)
+#define OSAL_TIMEOUT    (-1)
+#define OSAL_WOULD_BLOCK (-2)
+
+#define OSAL_WAIT_FOREVER ((uint32_t)0xFFFFFFFFU)
+
+typedef uint32_t OsalIrqIsrState;
+
+int  osal_is_in_isr(void);
+void osal_irq_lock_task(void);
+void osal_irq_unlock_task(void);
+OsalIrqIsrState osal_irq_lock_from_isr(void);
+void osal_irq_unlock_from_isr(OsalIrqIsrState state);
+
+static inline void osal_irq_lock(OsalIrqIsrState *key)
+{
+    if (osal_is_in_isr()) {
+        *key = osal_irq_lock_from_isr();
+    } else {
+        osal_irq_lock_task();
+        *key = 0U;
+    }
+}
+
+static inline void osal_irq_unlock(OsalIrqIsrState key)
+{
+    if (osal_is_in_isr()) {
+        osal_irq_unlock_from_isr(key);
+    } else {
+        osal_irq_unlock_task();
+    }
+}
+
+void osal_sleep_ms(uint32_t ms);
+
+#endif

--- a/samples/host/workqueue/osal/osal_sem.h
+++ b/samples/host/workqueue/osal/osal_sem.h
@@ -1,0 +1,20 @@
+#ifndef OM_OSAL_SEM_H
+#define OM_OSAL_SEM_H
+
+#include "osal_core.h"
+
+typedef struct OsalSemHandle_s OsalSem;
+
+OsalStatus osal_sem_create(OsalSem **sem, uint32_t max_count, uint32_t init_count);
+OsalStatus osal_sem_delete(OsalSem *sem);
+OsalStatus osal_sem_wait(OsalSem *sem, uint32_t timeout_ms);
+OsalStatus osal_sem_post(OsalSem *sem);
+OsalStatus osal_sem_post_from_isr(OsalSem *sem);
+
+static inline OsalStatus osal_sem_post_auto(OsalSem *sem)
+{
+    if (osal_is_in_isr()) return osal_sem_post_from_isr(sem);
+    return osal_sem_post(sem);
+}
+
+#endif

--- a/samples/host/workqueue/osal/osal_thread.h
+++ b/samples/host/workqueue/osal/osal_thread.h
@@ -1,0 +1,19 @@
+#ifndef OM_OSAL_THREAD_H
+#define OM_OSAL_THREAD_H
+
+#include "osal_core.h"
+
+typedef struct OsalThreadHandle_s OsalThread;
+typedef void (*OsalThreadEntryFunction)(void *arg);
+
+typedef struct {
+    const char *name;
+    uint32_t    stackSize;
+    uint32_t    priority;
+} OsalThreadAttr;
+
+OsalStatus osal_thread_create(OsalThread **thread, const OsalThreadAttr *attr,
+                              OsalThreadEntryFunction entry, void *arg);
+void osal_thread_exit(void);
+
+#endif

--- a/samples/host/workqueue/sync/completion.h
+++ b/samples/host/workqueue/sync/completion.h
@@ -1,0 +1,26 @@
+#ifndef __OM_SYNC_COMPLETION_H__
+#define __OM_SYNC_COMPLETION_H__
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "core/om_def.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct Completion {
+    void *_handle; /**< Win32 HANDLE (Event) */
+} Completion;
+
+OmRet completion_init(Completion *c);
+void  completion_deinit(Completion *c);
+OmRet completion_wait(Completion *c, size_t timeout_ms);
+OmRet completion_done(Completion *c);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __OM_SYNC_COMPLETION_H__ */

--- a/samples/host/workqueue/workqueue_host_test.c
+++ b/samples/host/workqueue/workqueue_host_test.c
@@ -1,0 +1,488 @@
+/**
+ * @file    workqueue_host_test.c
+ * @brief   Workqueue host 独立测试（Win32/pthread 平台）
+ *
+ * 移植自 samples/async/workqueue/main.c 的 13 个测试用例，
+ * 额外增加 flush 测试。
+ *
+ * 通过 Win32 API 模拟 OSAL 最小子集，直接编译 workqueue.c 源码。
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "async/workqueue.h"
+#include "data_struct/corelist.h"
+#include "osal/osal_core.h"
+#include "osal/osal_sem.h"
+#include "osal/osal_thread.h"
+#include "osal/osal_config.h"
+#include "sync/completion.h"
+
+/* --------------------------------------------------------------------------
+ * 测试结果追踪
+ * -------------------------------------------------------------------------- */
+
+static int g_total  = 0;
+static int g_failed = 0;
+static int g_current_test = 0;
+
+#define EXPECT(cond)                                          \
+    do {                                                      \
+        g_total++;                                            \
+        if (!(cond)) {                                        \
+            g_failed++;                                       \
+            fprintf(stderr, "  FAIL %s:%d\n", __FILE__, __LINE__); \
+        }                                                     \
+    } while (0)
+
+#define TEST_BEGIN(name)                              \
+    do {                                              \
+        g_current_test++;                             \
+        printf("[%2d] %-30s ", g_current_test, name); \
+    } while (0)
+
+#define TEST_END()                                    \
+    do {                                              \
+        printf("OK\n");                               \
+    } while (0)
+
+/* --------------------------------------------------------------------------
+ * 测试工作项
+ * -------------------------------------------------------------------------- */
+
+typedef struct {
+    Work     w;
+    OsalSem *s;
+    int      ex;
+    int      id;
+} TW;
+
+static void tw_handler(Work *w)
+{
+    TW *t = container_of(w, TW, w);
+    t->ex++;
+    if (t->s) osal_sem_post(t->s);
+}
+
+static void tw_init(TW *t, int id, OsalSem *s)
+{
+    work_init(&t->w, tw_handler, NULL);
+    t->s  = s;
+    t->ex = 0;
+    t->id = id;
+}
+
+static OsalSem *make_sem(void)
+{
+    OsalSem *s = NULL;
+    (void)osal_sem_create(&s, 1u, 0u);
+    return s;
+}
+
+static int wait_sem(OsalSem *s, uint32_t timeout_ms)
+{
+    return osal_sem_wait(s, timeout_ms) == OSAL_OK;
+}
+
+/* --------------------------------------------------------------------------
+ * 测试用例
+ * -------------------------------------------------------------------------- */
+
+/* 测试1：NULL 参数校验 */
+static void t_null_params(void)
+{
+    TEST_BEGIN("null_params");
+    Workqueue wq = {0};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
+
+    EXPECT(workqueue_init(&wq, &cfg) == OM_OK);
+    EXPECT(workqueue_enqueue(NULL, NULL) == OM_ERROR_PARAM);
+    EXPECT(workqueue_enqueue(&wq, NULL) == OM_ERROR_PARAM);
+    EXPECT(workqueue_cancel(NULL) == OM_ERROR_PARAM);
+    EXPECT(workqueue_init(NULL, &cfg) == OM_ERROR_PARAM);
+    EXPECT(workqueue_init(&wq, NULL) == OM_ERROR_PARAM);
+    EXPECT(workqueue_deinit(NULL) == OM_ERROR_PARAM);
+    EXPECT(workqueue_start(NULL) == OM_ERROR_PARAM);
+    EXPECT(workqueue_stop(NULL) == OM_ERROR_PARAM);
+    EXPECT(workqueue_get_state(NULL) == WORKQUEUE_STATE_UNINIT);
+    EXPECT(workqueue_is_empty(NULL) == true);
+    EXPECT(workqueue_deinit(&wq) == OM_OK);
+    TEST_END();
+}
+
+/* 测试2：生命周期状态机 */
+static void t_lifecycle(void)
+{
+    TEST_BEGIN("lifecycle");
+    Workqueue wq = {0};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
+
+    EXPECT(workqueue_get_state(&wq) == WORKQUEUE_STATE_UNINIT);
+    EXPECT(workqueue_init(&wq, &cfg) == OM_OK);
+    EXPECT(workqueue_get_state(&wq) == WORKQUEUE_STATE_IDLE);
+    EXPECT(workqueue_start(&wq) == OM_OK);
+    EXPECT(workqueue_get_state(&wq) == WORKQUEUE_STATE_RUNNING);
+    EXPECT(workqueue_start(&wq) != OM_OK);
+    EXPECT(workqueue_stop(&wq) == OM_OK);
+    EXPECT(workqueue_get_state(&wq) == WORKQUEUE_STATE_IDLE);
+    EXPECT(workqueue_stop(&wq) != OM_OK);
+    EXPECT(workqueue_start(&wq) == OM_OK);
+    EXPECT(workqueue_get_state(&wq) == WORKQUEUE_STATE_RUNNING);
+    EXPECT(workqueue_stop(&wq) == OM_OK);
+    EXPECT(workqueue_deinit(&wq) == OM_OK);
+    TEST_END();
+}
+
+/* 测试3：基本入队→执行 */
+static void t_basic(void)
+{
+    TEST_BEGIN("basic");
+    Workqueue wq = {0};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
+
+    EXPECT(workqueue_init(&wq, &cfg) == OM_OK);
+    EXPECT(workqueue_start(&wq) == OM_OK);
+
+    OsalSem *sem = make_sem();
+    TW t;
+    tw_init(&t, 42, sem);
+
+    EXPECT(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    EXPECT(wait_sem(sem, 5000u));
+    EXPECT(t.ex == 1);
+
+    EXPECT(workqueue_stop(&wq) == OM_OK);
+    EXPECT(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+    TEST_END();
+}
+
+/* 测试4：去重 */
+static void t_dedup(void)
+{
+    TEST_BEGIN("dedup");
+    Workqueue wq = {0};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
+
+    EXPECT(workqueue_init(&wq, &cfg) == OM_OK);
+    EXPECT(workqueue_start(&wq) == OM_OK);
+
+    OsalSem *sem = make_sem();
+    TW t;
+    tw_init(&t, 0, sem);
+
+    EXPECT(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    EXPECT(workqueue_enqueue(&wq, &t.w) == OM_ERROR_BUSY);
+    EXPECT(wait_sem(sem, 5000u));
+    EXPECT(t.ex == 1);
+
+    /* 完成后可重新入队 */
+    EXPECT(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    EXPECT(wait_sem(sem, 5000u));
+
+    EXPECT(workqueue_stop(&wq) == OM_OK);
+    EXPECT(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+    TEST_END();
+}
+
+/* 测试5：取消队列中尚未执行的工作项 */
+static void t_cancel_pending(void)
+{
+    TEST_BEGIN("cancel_pending");
+    Workqueue wq = {0};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
+
+    EXPECT(workqueue_init(&wq, &cfg) == OM_OK);
+    EXPECT(workqueue_start(&wq) == OM_OK);
+
+    TW t;
+    tw_init(&t, 0, NULL);
+
+    EXPECT(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    EXPECT(work_is_busy(&t.w));
+    EXPECT(workqueue_cancel(&t.w) == OM_OK);
+    EXPECT(!work_is_busy(&t.w));
+
+    osal_sleep_ms(100u);
+    EXPECT(t.ex == 0);
+
+    EXPECT(workqueue_stop(&wq) == OM_OK);
+    EXPECT(workqueue_deinit(&wq) == OM_OK);
+    TEST_END();
+}
+
+/* 测试6：已完成的工作项无法取消 */
+static void t_cancel_completed(void)
+{
+    TEST_BEGIN("cancel_completed");
+    Workqueue wq = {0};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
+
+    EXPECT(workqueue_init(&wq, &cfg) == OM_OK);
+    EXPECT(workqueue_start(&wq) == OM_OK);
+
+    OsalSem *sem = make_sem();
+    TW t;
+    tw_init(&t, 0, sem);
+
+    EXPECT(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    EXPECT(wait_sem(sem, 5000u));
+    EXPECT(t.ex == 1);
+
+    EXPECT(workqueue_cancel(&t.w) != OM_OK);
+
+    EXPECT(workqueue_stop(&wq) == OM_OK);
+    EXPECT(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+    TEST_END();
+}
+
+/* 测试7：5 个工作项中取消第 3 个 */
+static void t_cancel_one_of_many(void)
+{
+    TEST_BEGIN("cancel_one_of_many");
+    Workqueue wq = {0};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
+
+    EXPECT(workqueue_init(&wq, &cfg) == OM_OK);
+    EXPECT(workqueue_start(&wq) == OM_OK);
+
+    OsalSem *sem = make_sem();
+    TW t[5];
+    for (int i = 0; i < 5; i++) tw_init(&t[i], i, (i == 4) ? sem : NULL);
+
+    for (int i = 0; i < 5; i++) EXPECT(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
+    EXPECT(workqueue_cancel(&t[2].w) == OM_OK);
+
+    EXPECT(wait_sem(sem, 5000u));
+    EXPECT(t[0].ex == 1);
+    EXPECT(t[1].ex == 1);
+    EXPECT(t[2].ex == 0);
+    EXPECT(t[3].ex == 1);
+    EXPECT(t[4].ex == 1);
+
+    EXPECT(workqueue_stop(&wq) == OM_OK);
+    EXPECT(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+    TEST_END();
+}
+
+/* 测试8：取消后重新入队 */
+static void t_cancel_reenqueue(void)
+{
+    TEST_BEGIN("cancel_reenqueue");
+    Workqueue wq = {0};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
+
+    EXPECT(workqueue_init(&wq, &cfg) == OM_OK);
+    EXPECT(workqueue_start(&wq) == OM_OK);
+
+    TW t;
+    tw_init(&t, 0, NULL);
+
+    EXPECT(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    EXPECT(workqueue_cancel(&t.w) == OM_OK);
+    EXPECT(!work_is_busy(&t.w));
+
+    OsalSem *sem = make_sem();
+    t.s = sem;
+    EXPECT(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    EXPECT(wait_sem(sem, 5000u));
+    EXPECT(t.ex == 1);
+
+    EXPECT(workqueue_stop(&wq) == OM_OK);
+    EXPECT(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+    TEST_END();
+}
+
+/* 测试9：5 个工作项全部正常执行 */
+static void t_multi(void)
+{
+    TEST_BEGIN("multi");
+    Workqueue wq = {0};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
+
+    EXPECT(workqueue_init(&wq, &cfg) == OM_OK);
+    EXPECT(workqueue_start(&wq) == OM_OK);
+
+    OsalSem *sem = make_sem();
+    TW t[5];
+    for (int i = 0; i < 5; i++) tw_init(&t[i], i, (i == 4) ? sem : NULL);
+
+    for (int i = 0; i < 5; i++) EXPECT(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
+    EXPECT(wait_sem(sem, 5000u));
+
+    for (int i = 0; i < 5; i++) EXPECT(t[i].ex == 1);
+
+    EXPECT(workqueue_stop(&wq) == OM_OK);
+    EXPECT(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+    TEST_END();
+}
+
+/* 测试10：20 项压力测试 */
+static void t_stress(void)
+{
+    TEST_BEGIN("stress (20 items)");
+#define N 20
+    Workqueue wq = {0};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
+
+    EXPECT(workqueue_init(&wq, &cfg) == OM_OK);
+    EXPECT(workqueue_start(&wq) == OM_OK);
+
+    OsalSem *sem = make_sem();
+    TW t[N];
+    for (int i = 0; i < N; i++)
+        tw_init(&t[i], i, (i == N - 1) ? sem : NULL);
+
+    for (int i = 0; i < N; i++) EXPECT(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
+    EXPECT(wait_sem(sem, 10000u));
+
+    for (int i = 0; i < N; i++) EXPECT(t[i].ex == 1);
+
+    EXPECT(workqueue_stop(&wq) == OM_OK);
+    EXPECT(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+#undef N
+    TEST_END();
+}
+
+/* 测试11：stop 排空 */
+static void t_stop_drain(void)
+{
+    TEST_BEGIN("stop_drain");
+    Workqueue wq = {0};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
+
+    EXPECT(workqueue_init(&wq, &cfg) == OM_OK);
+    EXPECT(workqueue_start(&wq) == OM_OK);
+
+    OsalSem *sem = make_sem();
+    TW t;
+    tw_init(&t, 42, sem);
+
+    EXPECT(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    EXPECT(workqueue_stop(&wq) == OM_OK);
+    EXPECT(t.ex == 1);
+    EXPECT(!work_is_busy(&t.w));
+
+    EXPECT(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+    TEST_END();
+}
+
+/* 测试12：停止后入队被拒绝 */
+static void t_enq_stopped(void)
+{
+    TEST_BEGIN("enq_stopped");
+    Workqueue wq = {0};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
+
+    EXPECT(workqueue_init(&wq, &cfg) == OM_OK);
+    EXPECT(workqueue_start(&wq) == OM_OK);
+    EXPECT(workqueue_stop(&wq) == OM_OK);
+
+    TW t;
+    tw_init(&t, 0, NULL);
+    EXPECT(workqueue_enqueue(&wq, &t.w) == OM_ERROR);
+
+    EXPECT(workqueue_deinit(&wq) == OM_OK);
+    TEST_END();
+}
+
+/* 测试13：查询函数 */
+static void t_query(void)
+{
+    TEST_BEGIN("query");
+    Workqueue wq = {0};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
+
+    EXPECT(workqueue_init(&wq, &cfg) == OM_OK);
+    EXPECT(workqueue_start(&wq) == OM_OK);
+
+    OsalSem *sem = make_sem();
+    TW t;
+    tw_init(&t, 0, sem);
+
+    EXPECT(!work_is_busy(&t.w));
+    EXPECT(workqueue_is_empty(&wq));
+
+    EXPECT(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    EXPECT(work_is_busy(&t.w));
+    EXPECT(!workqueue_is_empty(&wq));
+
+    EXPECT(wait_sem(sem, 5000u));
+    EXPECT(!work_is_busy(&t.w));
+
+    EXPECT(workqueue_stop(&wq) == OM_OK);
+    EXPECT(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+    TEST_END();
+}
+
+/* 测试14：flush 排空并同步等待 */
+static void t_flush(void)
+{
+    TEST_BEGIN("flush");
+    Workqueue wq = {0};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
+
+    EXPECT(workqueue_init(&wq, &cfg) == OM_OK);
+    EXPECT(workqueue_start(&wq) == OM_OK);
+
+    OsalSem *sem = make_sem();
+    TW t[3];
+    for (int i = 0; i < 2; i++) tw_init(&t[i], i, NULL);
+    tw_init(&t[2], 2, sem);
+
+    for (int i = 0; i < 3; i++) EXPECT(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
+
+    /* flush 应等待全部工作项完成 */
+    EXPECT(workqueue_flush(&wq) == OM_OK);
+    for (int i = 0; i < 3; i++) EXPECT(t[i].ex == 1);
+
+    /* flush 后队列为空 */
+    EXPECT(workqueue_is_empty(&wq));
+
+    EXPECT(workqueue_stop(&wq) == OM_OK);
+    EXPECT(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+    TEST_END();
+}
+
+/* --------------------------------------------------------------------------
+ * main
+ * -------------------------------------------------------------------------- */
+
+int main(void)
+{
+    printf("=== Workqueue Host Test ===\n\n");
+
+    t_null_params();
+    t_lifecycle();
+    t_basic();
+    t_dedup();
+    t_cancel_pending();
+    t_cancel_completed();
+    t_cancel_one_of_many();
+    t_cancel_reenqueue();
+    t_multi();
+    t_stress();
+    t_stop_drain();
+    t_enq_stopped();
+    t_query();
+    t_flush();
+
+    printf("\n=== Results: %d/%d passed",
+           g_total - g_failed, g_total);
+    if (g_failed) {
+        printf(" (%d FAILED)", g_failed);
+    }
+    printf(" ===\n");
+
+    return g_failed ? 1 : 0;
+}

--- a/samples/host/workqueue/xmake.lua
+++ b/samples/host/workqueue/xmake.lua
@@ -1,0 +1,30 @@
+set_project("om_host_workqueue_test")
+set_xmakever("3.0.7")
+add_rules("mode.debug", "mode.release")
+
+target("host_wq_test")
+    set_kind("binary")
+    set_languages("gnu11")
+    set_warnings("all")
+
+    -- host stub 优先（osal/, sync/, data_struct/ 本地覆盖）
+    add_includedirs(".")
+    -- 平台无关头文件：core/om_def.h, port/, atomic/
+    add_includedirs("../../../lib/include")
+    -- 数据结构（被本地 data_struct/corelist.h 覆盖）
+    add_includedirs("../../../lib/data_struct/include")
+    -- async/workqueue.h
+    add_includedirs("../../../lib/async/include")
+
+    add_files("workqueue_host_test.c")
+    add_files("host_osal.c")
+    add_files("../../../lib/async/src/workqueue.c")
+
+    if is_plat("windows") then
+        set_toolchains("clang")
+        add_cxflags("-fms-extensions", {force = true})
+        add_syslinks("kernel32")
+    elseif is_plat("linux") then
+        add_syslinks("pthread")
+    end
+target_end()


### PR DESCRIPTION
## Summary

- **统一并发模型**：将 workqueue 从混合 irq_lock + 原子操作（CAS/LOAD_ACQ/STORE_REL）统一为纯 irq_lock + volatile，参考 Zephyr/NuttX 单核 MCU 设计模式
- **修复 flush 死锁**：用 barrier work 方案（参考 Linux `flush_workqueue`）替代有缺陷的双握手 `sem_wait`，通过 FIFO 语义保证 barrier 执行时之前所有 work 已完成
- **修复 enqueue TOCTOU 竞态**：将 flags 去重检查 + `list_add_tail` 移入同一 irq_lock 临界区，消除 CAS 与链表插入之间的时间窗口
- **简化状态机**：移除不可达的 `WORK_FLAG_CANCELLED`，Work.flags 简化为 IDLE→PENDING→RUNNING→IDLE 三态循环
- **新增 host 测试工程**：通过 Win32 API 模拟 OSAL，14 个测试用例（180 断言）全部通过

## 关键变更

| 变更 | 原实现 | 新实现 |
|------|--------|--------|
| 并发模型 | irq_lock + CAS/原子操作 | 纯 irq_lock + volatile |
| Work.flags 类型 | `OmAtomicUint` | `volatile uint32_t` |
| Workqueue.state 类型 | `OmAtomicInt` | `volatile int` |
| enqueue 去重 | irq_lock 外 CAS | irq_lock 内 flags 检查 |
| start/stop 状态切换 | `OM_CAS_AR` | irq_lock 内比较+赋值 |
| flush 实现 | 双握手 sem_post/sem_wait | barrier work + completion |
| cancel | CANCELLED 标志 + worker 检测 | 直接 list_del + IDLE |

## 文件变更

- `lib/async/include/async/workqueue.h` — 移除 atomic 依赖，简化 flags 和类型
- `lib/async/src/workqueue.c` — 核心重构（enqueue/cancel/worker/flush/start/stop）
- `lib/async/docs/workqueue.md` — 更新设计文档（并发模型、状态机图）
- `samples/host/workqueue/` — 新增独立 host 测试工程（9 文件）

## Test plan

- [x] Win32 host 测试：14 用例 / 180 断言全部通过
  - null_params, lifecycle, basic, dedup, cancel_pending, cancel_completed, cancel_one_of_many, cancel_reenqueue, multi, stress(20), stop_drain, enq_stopped, query, flush
- [x] armclang 交叉编译零警告
- [x] FreeRTOS 目标实机运行验证（需硬件）