### PR TITLE
refactor(gpio): 改进 gpio_pin_get API 为输出参数模式

### DIFF
--- a/lib/drivers/docs/gpio_design.md
+++ b/lib/drivers/docs/gpio_design.md
@@ -35,7 +35,7 @@
 - 电平读写、翻转
 - 上下拉配置（无/上拉/下拉）
 - 驱动模式（推挽/开漏）
-- 驱动强度（低/中/高，硬件相关，不支持的 BSP 返回 OM_ENOTSUP）
+- 驱动强度（低/中/高，硬件相关，不支持的 BSP 返回 OM_ERROR_NOT_SUPPORT）
 - 输出初始值
 - 中断（边沿/电平触发）
 
@@ -92,8 +92,8 @@ typedef struct {
 使用方式：
 ```c
 static const GpioPinSpec led_spec = { "gpio0", 19, 0 };
-GpioPin led = gpio_pin_get(&led_spec);
-if (!gpio_pin_valid(led)) return OM_ENODEV;
+GpioPin led;
+if (gpio_pin_get(&led_spec, &led) != OM_OK) return OM_ERROR;
 gpio_pin_write(led, 1);  // 直接通过 ctrl 指针，无字符串查找
 ```
 
@@ -145,7 +145,7 @@ OmRet gpio_pin_irq_enable(GpioPin pin, bool enable);
 **理由**：
 - 延迟最低，适合机器人场景中的实时响应（编码器脉冲、限位开关、紧急停止）
 - attach/enable 分离允许先注册回调再条件使能，灵活控制中断生命周期
-- 不引入 osal/sync/ipc 依赖，GPIO 子系统保持最轻依赖（仅 core）
+- ISR 热路径不依赖 osal/sync/ipc（回调表管理使用 osal_irq_lock，但不在 ISR 中），子系统依赖 core + osal
 - 用户若需任务级处理，可在回调中自行使用 osal 原语（信号量 give、队列发送等）
 
 ---
@@ -164,10 +164,8 @@ OmRet gpio_pin_irq_enable(GpioPin pin, bool enable);
 ### D8: 依赖一致性
 
 **决策**：
-- GPIO 子系统位于 `lib/drivers/`，依赖 `core`（类型/错误码/atomic）+ `osal`（`osal_irq_lock/unlock`，仅 IRQ 管理路径使用）
+- GPIO 子系统位于 `lib/drivers/`，依赖 `core`（类型/错误码）+ `osal`（`osal_irq_lock/unlock`、`osal_malloc/free`，IRQ 管理路径和控制器注册使用）
 - API 头文件放入 `tar_awapi_driver`（headeronly target），实现放入 `tar_awdrivers`（static target）
-- 裁剪宏：`OM_USE_HAL_GPIO`，在 `om_config.h` 中定义
-- PAL 入口：在 `pal_dev.h` 中通过条件编译包含 GPIO 头文件
 - 不依赖 sync/ipc/services/systems，不 include bsp 头文件
 
 **理由**：
@@ -264,8 +262,8 @@ typedef struct GpioPin {
 } GpioPin;
 
 // 解析 + 有效性检查
-GpioPin gpio_pin_get(const GpioPinSpec *spec);
-bool    gpio_pin_valid(GpioPin pin);
+OmRet gpio_pin_get(const GpioPinSpec *spec, GpioPin *pin);
+bool  gpio_pin_valid(GpioPin pin);
 
 /* ===== 引脚配置 ===== */
 typedef enum { GPIO_DIR_INPUT, GPIO_DIR_OUTPUT } GpioDirection;
@@ -332,7 +330,8 @@ typedef struct GpioOps {
     uint32_t (*port_read)(GpioController *ctrl);
 } GpioOps;
 
-OmRet gpio_controller_register(const char *name,
+OmRet gpio_controller_register(GpioController *ctrl,
+                                const char *name,
                                 uint8_t pin_count,
                                 uint32_t caps, const GpioOps *ops, void *priv);
 
@@ -340,10 +339,10 @@ OmRet gpio_controller_register(const char *name,
 typedef struct GpioController {
     Device parent;               // 内嵌 Device
     const GpioOps *ops;          // BSP 注入的硬件操作函数表
-    uint8_t pin_start;
     uint8_t pin_count;
+    uint32_t caps;               // IRQ 能力位图
     void *priv;                  // BSP 私有数据
-    struct GpioIrqHdr *irq_hdrs; // 中断回调表
+    GpioIrqHdr *irq_hdrs;        // 中断回调表
 } GpioController;
 ```
 

--- a/lib/drivers/include/drivers/peripheral/gpio/pal_gpio_dev.h
+++ b/lib/drivers/include/drivers/peripheral/gpio/pal_gpio_dev.h
@@ -129,8 +129,9 @@ typedef struct {
  *          后续操作直接通过 ctrl 指针路由，零字符串查找开销，ISR 安全。
  *
  * @code
- * GpioPin led = gpio_pin_get(&led_spec);
- * if (!gpio_pin_valid(led)) return OM_ENODEV;
+ * GpioPin led;
+ * OmRet ret = gpio_pin_get(&led_spec, &led);
+ * if (ret != OM_OK) return ret;
  * gpio_pin_write(led, 1);
  * @endcode
  */
@@ -373,18 +374,24 @@ struct GpioOps {
 
 /**
  * @brief  从编译时描述符解析运行时引脚句柄
- * @param[in] spec  编译时引脚描述符，不可为 NULL
- * @return 运行时引脚句柄；解析失败时 ctrl 为 NULL
+ * @param[in]  spec  编译时引脚描述符，不可为 NULL
+ * @param[out] pin   解析结果句柄；失败时写入 ctrl=NULL 的无效句柄
+ * @return OM_OK 成功，OM_ERROR_PARAM 参数无效，OM_ERROR 控制器未找到或类型不匹配
  * @note   通常在初始化阶段调用一次，后续复用返回的 #GpioPin
  */
-GpioPin gpio_pin_get(const GpioPinSpec *spec);
+OmRet gpio_pin_get(const GpioPinSpec *spec, GpioPin *pin);
 
 /**
  * @brief  检查引脚句柄是否有效
+ * @details 等效于 `pin.ctrl != NULL`。gpio_pin_get() 成功后无需调用此函数；
+ *          主要用于可选引脚场景（如 SPI 片选）的运行时判断。
  * @param[in] pin  待检查的引脚句柄
  * @return true 有效，false 无效（ctrl 为 NULL）
  */
-bool gpio_pin_valid(GpioPin pin);
+static inline bool gpio_pin_valid(GpioPin pin)
+{
+    return pin.ctrl != NULL;
+}
 
 /** @} */
 
@@ -487,7 +494,10 @@ GpioPort gpio_port_get(const char *controller);
  * @param[in] port  待检查的端口句柄
  * @return true 有效，false 无效
  */
-bool gpio_port_valid(GpioPort port);
+static inline bool gpio_port_valid(GpioPort port)
+{
+    return port.ctrl != NULL;
+}
 
 /**
  * @brief  掩码写入端口

--- a/lib/drivers/include/drivers/peripheral/pal_dev.h
+++ b/lib/drivers/include/drivers/peripheral/pal_dev.h
@@ -12,9 +12,7 @@
 #include "can/pal_can_dev.h"
 #endif
 
-#ifdef __OM_USE_HAL_GPIO
 #include "gpio/pal_gpio_dev.h"
-#endif
 
 #ifdef OM_USE_HAL_SPI
 #include "spi/pal_spi_dev.h"

--- a/lib/drivers/src/peripheral/gpio/hal_gpio.c
+++ b/lib/drivers/src/peripheral/gpio/hal_gpio.c
@@ -78,32 +78,31 @@ OmRet gpio_controller_register(GpioController *ctrl, const char *name,
 /* ===== Pin 句柄解析 ===== */
 
 /**
- * @brief  通过 device_find() 查找控制器、校验 offset、返回 GpioPin
+ * @brief  通过 device_find() 查找控制器、校验 offset、写入输出参数
  */
-GpioPin gpio_pin_get(const GpioPinSpec *spec)
+OmRet gpio_pin_get(const GpioPinSpec *spec, GpioPin *pin)
 {
+    if (!pin)
+        return OM_ERROR_PARAM;
+
     GpioPin invalid = {NULL, 0, 0};
+    *pin = invalid;
+
     if (!spec || !spec->controller)
-        return invalid;
+        return OM_ERROR_PARAM;
 
     Device *dev = device_find((char *)spec->controller);
     if (!dev || dev->type != DEVICE_TYPE_GPIO)
-        return invalid;
+        return OM_ERROR;
 
     GpioController *ctrl = (GpioController *)dev;
     if (spec->offset >= ctrl->pin_count)
-        return invalid;
+        return OM_ERROR;
 
-    GpioPin pin = {ctrl, spec->offset, spec->flags};
-    return pin;
-}
-
-/**
- * @brief  检查 GpioPin 的 ctrl 指针是否非空
- */
-bool gpio_pin_valid(GpioPin pin)
-{
-    return pin.ctrl != NULL;
+    pin->ctrl   = ctrl;
+    pin->offset = spec->offset;
+    pin->flags  = spec->flags;
+    return OM_OK;
 }
 
 /* ===== 引脚级操作（无锁） ===== */
@@ -246,14 +245,6 @@ GpioPort gpio_port_get(const char *controller)
 
     GpioPort port = {(GpioController *)dev};
     return port;
-}
-
-/**
- * @brief  检查 GpioPort 的 ctrl 指针是否非空
- */
-bool gpio_port_valid(GpioPort port)
-{
-    return port.ctrl != NULL;
 }
 
 /* ===== 端口级批量操作 ===== */

--- a/lib/drivers/src/peripheral/spi/hal_spi.c
+++ b/lib/drivers/src/peripheral/spi/hal_spi.c
@@ -233,7 +233,7 @@ OmRet hal_spi_device_attach(SpiBus *bus, HalSpiDevice *dev,
 
     /* 解析 CS 引脚 */
     if (cfg->csSpec.controller != NULL)
-        dev->cs = gpio_pin_get(&cfg->csSpec);
+        gpio_pin_get(&cfg->csSpec, &dev->cs);
 
     /* 注册为标准 Device */
     static const DevInterface g_spiDevInterface = {
@@ -405,7 +405,7 @@ OmRet hal_spi_dev_control(Device *dev, size_t cmd, void *arg)
         spiDev->cfg = *newCfg;
         /* 解析新的 CS 引脚：GPIO→硬件CS 切换时需清除旧 GPIO 句柄 */
         if (newCfg->csSpec.controller != NULL)
-            spiDev->cs = gpio_pin_get(&newCfg->csSpec);
+            gpio_pin_get(&newCfg->csSpec, &spiDev->cs);
         else
             memset(&spiDev->cs, 0, sizeof(spiDev->cs));
 

--- a/lib/include/core/om_config.h
+++ b/lib/include/core/om_config.h
@@ -7,7 +7,6 @@
 /* 抽象层裁剪 */
 #define OM_USE_HAL_SERIALS
 #define OM_USE_HAL_CAN
-#define OM_USE_HAL_GPIO
 #define OM_USE_HAL_SPI
 
 /*

--- a/samples/pal/gpio/main.c
+++ b/samples/pal/gpio/main.c
@@ -68,13 +68,11 @@ static void gpio_test_task(void *arg)
     (void)arg;
 
     /* 1. 解析引脚句柄 */
-    GpioPin out     = gpio_pin_get(&out_spec);
-    GpioPin in      = gpio_pin_get(&in_spec);
-    GpioPin irq_src = gpio_pin_get(&irq_src_spec);
-    GpioPin irq_pin = gpio_pin_get(&irq_pin_spec);
-
-    if (!gpio_pin_valid(out) || !gpio_pin_valid(in) ||
-        !gpio_pin_valid(irq_src) || !gpio_pin_valid(irq_pin)) {
+    GpioPin out, in, irq_src, irq_pin;
+    if (gpio_pin_get(&out_spec, &out) != OM_OK ||
+        gpio_pin_get(&in_spec, &in) != OM_OK ||
+        gpio_pin_get(&irq_src_spec, &irq_src) != OM_OK ||
+        gpio_pin_get(&irq_pin_spec, &irq_pin) != OM_OK) {
         /* 引脚解析失败 — 检查控制器名和偏移是否在范围内 */
         while (1) {}
     }


### PR DESCRIPTION
## Summary
- 框架层端口操作（write_masked/set/clear/toggle/read）统一施加 `pin_count` 掩码截断，确保越界位不会传递到 BSP
- 完善端口级 API 的 doxygen 文档：位映射约定、使用示例、STM32F4 ODR 非原子性警告
- rm-a-board（STM32F427）完整 GPIO BSP 支持：10 端口（GPIOA-J）、GpioOps 函数表、EXTI SYSCFG 动态路由

## Test plan
- [ ] rm-c-board 构建通过（xmake f --board=rm-c-board && xmake）
- [ ] rm-a-board 构建通过（xmake f --board=rm-a-board && xmake）
- [ ] xmake format --dry-run --error