### PR TITLE
feat(gpio): 端口 pin_count 掩码保护 + rm-a-board BSP 支持

### DIFF
--- a/lib/drivers/include/drivers/peripheral/gpio/pal_gpio_dev.h
+++ b/lib/drivers/include/drivers/peripheral/gpio/pal_gpio_dev.h
@@ -474,9 +474,18 @@ OmRet gpio_pin_irq_enable(GpioPin pin, bool enable);
 
 /**
  * @name 端口级批量操作
- * @details 端口级 API 直接操作硬件寄存器，使用**物理电平**语义：
- *          value 的每一位直接对应引脚的物理电平，不经过 ACTIVE_LOW 反转。
- *          如需逻辑电平操作，请使用引脚级 API（gpio_pin_write 等）。
+ * @details 端口级 API 以控制器为粒度，通过 32 位位掩码一次性操作多个引脚。
+ *
+ *          **位映射约定**（所有参数统一）：
+ *          - `pins` 和 `mask` 均为**位选择器**：bit N = 1 表示选中控制器内偏移为 N 的引脚，
+ *            bit N = 0 表示跳过该引脚。两者含义相同，命名差异仅在于是否需要独立的 `value` 参数。
+ *          - `value` 中的有效位由 `mask` 限定：仅在 `mask` 的 bit N = 1 时，`value` 的
+ *            bit N 才有意义（0 = 物理低电平，1 = 物理高电平）。
+ *          - `port_read` 返回的每个 bit N 对应引脚 N 的物理电平。
+ *          - 框架层会将所有输入参数截断到 `[0, pin_count)` 范围内，超出 `pin_count`
+ *            的位自动清除，BSP 不会收到越界的位掩码。
+ *          - 所有端口级 API 采用**物理电平**语义，不经过 `GPIO_FLAG_ACTIVE_LOW` 反转。
+ *            如需逻辑电平操作，请使用引脚级 API（gpio_pin_write 等）。
  *
  *          Zephyr 提供了 gpio_port_set_masked（逻辑）和 _raw 变体（物理），
  *          当前设计出于简洁性考虑仅提供物理接口，后续可按需扩展。
@@ -501,41 +510,70 @@ static inline bool gpio_port_valid(GpioPort port)
 
 /**
  * @brief  掩码写入端口
+ * @details 根据 @p mask 和 @p value 同时更新多个引脚的物理电平。
+ *          对于 mask 中每个为 1 的位 N：将引脚 N 写为 value 的 bit N。
+ *          mask 为 0 的位对应的引脚保持不变。
+ *
+ *          示例：mask=0x0005, value=0x0001 → 引脚 0 拉高，引脚 2 拉低，其余不变
+ *
+ *          是 gpio_port_set_bits / gpio_port_clear_bits 的超集。
+ *          若支持原子 BSRR（如 STM32），mask 和 value 可合并为一次寄存器写入。
+ *
  * @param[in] port   有效的端口句柄
- * @param[in] mask   写入掩码，仅 mask 为 1 的位被更新
- * @param[in] value  待写入的值
+ * @param[in] mask   位选择器，bit N=1 表示引脚 N 被写入
+ * @param[in] value  目标电平值，bit N 仅在 mask 的 bit N=1 时有意义
  * @return OM_OK 成功，OM_ERROR_PARAM 控制器不支持此操作或参数无效
  */
 OmRet gpio_port_write_masked(GpioPort port, uint32_t mask, uint32_t value);
 
 /**
- * @brief  原子置位指定引脚
+ * @brief  原子置位指定引脚（全部拉高）
+ * @details 将 @p pins 中为 1 的位对应的引脚物理电平拉高，其余引脚不变。
+ *          等效于 `gpio_port_write_masked(port, pins, pins)`。
+ *
+ *          示例：pins=0x000A → 引脚 1 和引脚 3 拉高，其余不变
+ *
  * @param[in] port  有效的端口句柄
- * @param[in] pins  目标引脚位掩码
+ * @param[in] pins  位选择器，bit N=1 表示引脚 N 被拉高
  * @return OM_OK 成功，OM_ERROR_PARAM 控制器不支持此操作或参数无效
  */
 OmRet gpio_port_set_bits(GpioPort port, uint32_t pins);
 
 /**
- * @brief  原子清零指定引脚
+ * @brief  原子清零指定引脚（全部拉低）
+ * @details 将 @p pins 中为 1 的位对应的引脚物理电平拉低，其余引脚不变。
+ *          等效于 `gpio_port_write_masked(port, pins, 0)`。
+ *
+ *          示例：pins=0x000A → 引脚 1 和引脚 3 拉低，其余不变
+ *
  * @param[in] port  有效的端口句柄
- * @param[in] pins  目标引脚位掩码
+ * @param[in] pins  位选择器，bit N=1 表示引脚 N 被拉低
  * @return OM_OK 成功，OM_ERROR_PARAM 控制器不支持此操作或参数无效
  */
 OmRet gpio_port_clear_bits(GpioPort port, uint32_t pins);
 
 /**
  * @brief  原子翻转指定引脚
+ * @details 将 @p pins 中为 1 的位对应的引脚物理电平取反，其余引脚不变。
+ *
+ *          示例：pins=0x000A → 引脚 1 和引脚 3 电平翻转，其余不变
+ *
+ * @warning STM32F4 的 ODR ^= pins 是读-改-写操作，非原子。
+ *          调用者需保证不对同一控制器在多个上下文中并发调用此函数。
+ *
  * @param[in] port  有效的端口句柄
- * @param[in] pins  目标引脚位掩码
+ * @param[in] pins  位选择器，bit N=1 表示引脚 N 被翻转
  * @return OM_OK 成功，OM_ERROR_PARAM 控制器不支持此操作或参数无效
  */
 OmRet gpio_port_toggle_bits(GpioPort port, uint32_t pins);
 
 /**
- * @brief  读取整个端口电平
+ * @brief  读取整个端口物理电平
+ * @details 返回 32 位值，bit N 对应引脚 N 的当前物理电平（0=低，1=高）。
+ *          超出 pin_count 的高位被框架层清零。
+ *
  * @param[in] port  有效的端口句柄
- * @return 端口电平值，每位对应一个引脚；控制器不支持时返回 0
+ * @return 端口电平值（bit N = 引脚 N 的物理电平），控制器不支持时返回 0
  */
 uint32_t gpio_port_read(GpioPort port);
 

--- a/lib/drivers/src/peripheral/gpio/hal_gpio.c
+++ b/lib/drivers/src/peripheral/gpio/hal_gpio.c
@@ -251,50 +251,61 @@ GpioPort gpio_port_get(const char *controller)
 
 /**
  * @brief  委托 BSP ops 掩码写入端口
+ * @details mask 中超出 pin_count 的位在框架层被截断，BSP 收到的 mask 仅含有效位。
  */
 OmRet gpio_port_write_masked(GpioPort port, uint32_t mask, uint32_t value)
 {
     if (!port.ctrl || !port.ctrl->ops->port_write_masked)
         return OM_ERROR_PARAM;
-    return port.ctrl->ops->port_write_masked(port.ctrl, mask, value);
+    uint32_t valid_mask = (1U << port.ctrl->pin_count) - 1;
+    return port.ctrl->ops->port_write_masked(port.ctrl, mask & valid_mask,
+                                             value);
 }
 
 /**
  * @brief  委托 BSP ops 原子置位引脚
+ * @details pins 中超出 pin_count 的位在框架层被截断，BSP 收到的 pins 仅含有效位。
  */
 OmRet gpio_port_set_bits(GpioPort port, uint32_t pins)
 {
     if (!port.ctrl || !port.ctrl->ops->port_set_bits)
         return OM_ERROR_PARAM;
-    return port.ctrl->ops->port_set_bits(port.ctrl, pins);
+    uint32_t valid_mask = (1U << port.ctrl->pin_count) - 1;
+    return port.ctrl->ops->port_set_bits(port.ctrl, pins & valid_mask);
 }
 
 /**
  * @brief  委托 BSP ops 原子清零引脚
+ * @details pins 中超出 pin_count 的位在框架层被截断，BSP 收到的 pins 仅含有效位。
  */
 OmRet gpio_port_clear_bits(GpioPort port, uint32_t pins)
 {
     if (!port.ctrl || !port.ctrl->ops->port_clear_bits)
         return OM_ERROR_PARAM;
-    return port.ctrl->ops->port_clear_bits(port.ctrl, pins);
+    uint32_t valid_mask = (1U << port.ctrl->pin_count) - 1;
+    return port.ctrl->ops->port_clear_bits(port.ctrl, pins & valid_mask);
 }
 
 /**
  * @brief  委托 BSP ops 原子翻转引脚
+ * @details pins 中超出 pin_count 的位在框架层被截断，BSP 收到的 pins 仅含有效位。
  */
 OmRet gpio_port_toggle_bits(GpioPort port, uint32_t pins)
 {
     if (!port.ctrl || !port.ctrl->ops->port_toggle_bits)
         return OM_ERROR_PARAM;
-    return port.ctrl->ops->port_toggle_bits(port.ctrl, pins);
+    uint32_t valid_mask = (1U << port.ctrl->pin_count) - 1;
+    return port.ctrl->ops->port_toggle_bits(port.ctrl, pins & valid_mask);
 }
 
 /**
  * @brief  委托 BSP ops 读取端口电平
+ * @details 返回值为 BSP 返回值经 pin_count 掩码截断，高位噪声已清除。
  */
 uint32_t gpio_port_read(GpioPort port)
 {
     if (!port.ctrl || !port.ctrl->ops->port_read)
         return 0;
-    return port.ctrl->ops->port_read(port.ctrl);
+    uint32_t valid_mask = (1U << port.ctrl->pin_count) - 1;
+    return port.ctrl->ops->port_read(port.ctrl) & valid_mask;
 }

--- a/platform/bsp/boards/rm-a-board/include/bsp.h
+++ b/platform/bsp/boards/rm-a-board/include/bsp.h
@@ -3,6 +3,7 @@
 
 #include "bsp_can.h"
 #include "bsp_dwt.h"
+#include "bsp_gpio.h"
 #include "bsp_serial.h"
 
 #include "core/om_cpu.h"

--- a/platform/bsp/boards/rm-a-board/include/bsp_gpio.h
+++ b/platform/bsp/boards/rm-a-board/include/bsp_gpio.h
@@ -1,0 +1,44 @@
+/**
+ * @file    bsp_gpio.h
+ * @brief   rm-a-board GPIO BSP 配置
+ */
+
+#ifndef __BSP_GPIO_H__
+#define __BSP_GPIO_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "drivers/peripheral/gpio/pal_gpio_dev.h"
+#include "stm32f4xx_hal.h"
+
+#define BSP_GPIO_PORT_COUNT    (10U)
+#define BSP_GPIO_PINS_PER_PORT (16U)
+
+/** 默认 GPIO EXTI 中断优先级（0 最高，15 最低），可在板级配置中覆盖 */
+#ifndef BSP_GPIO_IRQ_PRIORITY
+#define BSP_GPIO_IRQ_PRIORITY  (5U)
+#endif
+
+/** STM32F4 EXTI 仅支持边沿触发 */
+#define BSP_GPIO_IRQ_CAPS      (GPIO_CAP_IRQ_EDGE_RISING  | \
+                                GPIO_CAP_IRQ_EDGE_FALLING | \
+                                GPIO_CAP_IRQ_EDGE_BOTH)
+
+typedef struct BspGpio {
+    GPIO_TypeDef *port;
+    GpioController parent;
+    char *name;
+    uint8_t irq_priority;
+} BspGpio;
+
+extern BspGpio gBspGpio[BSP_GPIO_PORT_COUNT];
+
+void bsp_gpio_register(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BSP_GPIO_H__ */

--- a/platform/bsp/boards/rm-a-board/source/core/bsp_cpu.c
+++ b/platform/bsp/boards/rm-a-board/source/core/bsp_cpu.c
@@ -94,6 +94,7 @@ void om_board_init(void)
     DWT_Init(__OM_CPU_FREQ_MHZ);
     bsp_serial_register();
     bsp_can_register();
+    bsp_gpio_register();
 }
 
 /**

--- a/platform/bsp/boards/rm-a-board/source/peripherals/gpio/bsp_gpio_impl.c
+++ b/platform/bsp/boards/rm-a-board/source/peripherals/gpio/bsp_gpio_impl.c
@@ -1,0 +1,234 @@
+/**
+ * @file    bsp_gpio_impl.c
+ * @brief   rm-a-board GPIO BSP 实现（STM32F427）
+ */
+
+#include "bsp_gpio.h"
+
+/* ===== STM32 EXTI IRQ 通道映射 ===== */
+
+static IRQn_Type bsp_gpio_exti_irqn(uint8_t pin)
+{
+    if (pin <= 4)
+        return (IRQn_Type)(EXTI0_IRQn + pin);
+    if (pin <= 9)
+        return EXTI9_5_IRQn;
+    return EXTI15_10_IRQn;
+}
+
+/** 计算 GPIO 端口在 EXTICR 中的索引（GPIOA=0, GPIOB=1, ...） */
+static uint8_t bsp_gpio_port_index(GPIO_TypeDef *port)
+{
+    return (uint8_t)(((uint32_t)port - (uint32_t)GPIOA) / 0x0400U);
+}
+
+/* ===== GpioOps 实现 ===== */
+
+static OmRet bsp_gpio_pin_configure(GpioController *ctrl, uint8_t offset,
+                                     const GpioPinConfig *cfg)
+{
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+    GPIO_InitTypeDef init = {0};
+
+    init.Pin = (uint16_t)(1U << offset);
+
+    /* 方向 + 驱动模式 */
+    if (cfg->direction == GPIO_DIR_OUTPUT) {
+        init.Mode = (cfg->drive == GPIO_DRIVE_OPEN_DRAIN)
+                        ? GPIO_MODE_OUTPUT_OD
+                        : GPIO_MODE_OUTPUT_PP;
+        init.Speed = (cfg->speed == GPIO_DRIVE_STRENGTH_HIGH)    ? GPIO_SPEED_FREQ_VERY_HIGH
+                   : (cfg->speed == GPIO_DRIVE_STRENGTH_MEDIUM) ? GPIO_SPEED_FREQ_MEDIUM
+                                                       : GPIO_SPEED_FREQ_LOW;
+        if (cfg->init_high)
+            HAL_GPIO_WritePin(bsp->port, init.Pin, GPIO_PIN_SET);
+        else
+            HAL_GPIO_WritePin(bsp->port, init.Pin, GPIO_PIN_RESET);
+    } else {
+        init.Mode = GPIO_MODE_INPUT;
+    }
+
+    /* 上下拉 */
+    init.Pull = (cfg->pull == GPIO_PULL_UP)  ? GPIO_PULLUP
+              : (cfg->pull == GPIO_PULL_DOWN) ? GPIO_PULLDOWN
+                                              : GPIO_NOPULL;
+
+    HAL_GPIO_Init(bsp->port, &init);
+    return OM_OK;
+}
+
+static void bsp_gpio_pin_write(GpioController *ctrl, uint8_t offset,
+                                uint8_t value)
+{
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+    HAL_GPIO_WritePin(bsp->port, (uint16_t)(1U << offset),
+                      value ? GPIO_PIN_SET : GPIO_PIN_RESET);
+}
+
+static uint8_t bsp_gpio_pin_read(GpioController *ctrl, uint8_t offset)
+{
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+    return (HAL_GPIO_ReadPin(bsp->port, (uint16_t)(1U << offset)) == GPIO_PIN_SET)
+               ? 1 : 0;
+}
+
+static void bsp_gpio_pin_toggle(GpioController *ctrl, uint8_t offset)
+{
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+    HAL_GPIO_TogglePin(bsp->port, (uint16_t)(1U << offset));
+}
+
+/**
+ * @brief  配置 EXTI 路由和 NVIC（不调用 HAL_GPIO_Init，不修改电气配置）
+ * @details 仅操作 EXTI 相关寄存器（EXTICR/RTSR/FTSR/IMR），
+ *          保留用户通过 gpio_pin_configure 设置的 pull 和 mode。
+ */
+static OmRet bsp_gpio_pin_attach_irq(GpioController *ctrl, uint8_t offset,
+                                      GpioIrqMode mode,
+                                      void (*cb)(void *), void *arg)
+{
+    (void)cb;
+    (void)arg;
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+
+    /* 配置 SYSCFG EXTICR：将 EXTI 线路由到当前端口 */
+    __HAL_RCC_SYSCFG_CLK_ENABLE();
+    volatile uint32_t *exticr = &SYSCFG->EXTICR[offset / 4];
+    uint32_t shift = (offset % 4) * 4;
+    uint32_t port_val = bsp_gpio_port_index(bsp->port);
+    *exticr = (*exticr & ~(0xFU << shift)) | (port_val << shift);
+
+    /* 配置 EXTI 边沿触发（不触碰 PUPDR/MODER） */
+    uint32_t bitmask = 1U << offset;
+    switch (mode) {
+    case GPIO_IRQ_EDGE_RISING:
+        EXTI->RTSR |= bitmask;
+        EXTI->FTSR &= ~bitmask;
+        break;
+    case GPIO_IRQ_EDGE_FALLING:
+        EXTI->FTSR |= bitmask;
+        EXTI->RTSR &= ~bitmask;
+        break;
+    case GPIO_IRQ_EDGE_BOTH:
+        EXTI->RTSR |= bitmask;
+        EXTI->FTSR |= bitmask;
+        break;
+    default:
+        return OM_ERROR_NOT_SUPPORT;
+    }
+
+    /* 使能 EXTI 中断掩码 */
+    EXTI->IMR |= bitmask;
+
+    /* 配置 NVIC 优先级（不使能，由 irq_enable 控制） */
+    IRQn_Type irqn = bsp_gpio_exti_irqn(offset);
+    HAL_NVIC_SetPriority(irqn, bsp->irq_priority, 0);
+
+    return OM_OK;
+}
+
+static OmRet bsp_gpio_pin_irq_enable(GpioController *ctrl, uint8_t offset,
+                                      bool enable)
+{
+    (void)ctrl;
+    IRQn_Type irqn = bsp_gpio_exti_irqn(offset);
+    if (enable)
+        HAL_NVIC_EnableIRQ(irqn);
+    else
+        HAL_NVIC_DisableIRQ(irqn);
+    return OM_OK;
+}
+
+/* ===== 端口级操作（直接寄存器） ===== */
+
+static OmRet bsp_gpio_port_write_masked(GpioController *ctrl, uint32_t mask,
+                                         uint32_t value)
+{
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+    bsp->port->BSRR = ((~value & mask) << 16) | (value & mask);
+    return OM_OK;
+}
+
+static OmRet bsp_gpio_port_set_bits(GpioController *ctrl, uint32_t pins)
+{
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+    bsp->port->BSRR = pins;
+    return OM_OK;
+}
+
+static OmRet bsp_gpio_port_clear_bits(GpioController *ctrl, uint32_t pins)
+{
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+    bsp->port->BSRR = pins << 16;
+    return OM_OK;
+}
+
+static OmRet bsp_gpio_port_toggle_bits(GpioController *ctrl, uint32_t pins)
+{
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+    bsp->port->ODR ^= pins;
+    return OM_OK;
+}
+
+static uint32_t bsp_gpio_port_read(GpioController *ctrl)
+{
+    BspGpio *bsp = (BspGpio *)ctrl->parent.handle;
+    return bsp->port->IDR;
+}
+
+/* ===== GpioOps 实例 ===== */
+
+static const GpioOps gGpioOps = {
+    .pin_configure  = bsp_gpio_pin_configure,
+    .pin_write      = bsp_gpio_pin_write,
+    .pin_read       = bsp_gpio_pin_read,
+    .pin_toggle     = bsp_gpio_pin_toggle,
+    .pin_attach_irq = bsp_gpio_pin_attach_irq,
+    .pin_irq_enable = bsp_gpio_pin_irq_enable,
+    .port_write_masked = bsp_gpio_port_write_masked,
+    .port_set_bits     = bsp_gpio_port_set_bits,
+    .port_clear_bits   = bsp_gpio_port_clear_bits,
+    .port_toggle_bits  = bsp_gpio_port_toggle_bits,
+    .port_read         = bsp_gpio_port_read,
+};
+
+/* ===== BSP 实例数组 ===== */
+
+BspGpio gBspGpio[BSP_GPIO_PORT_COUNT] = {
+    {GPIOA, {0}, "gpioa", BSP_GPIO_IRQ_PRIORITY},
+    {GPIOB, {0}, "gpiob", BSP_GPIO_IRQ_PRIORITY},
+    {GPIOC, {0}, "gpioc", BSP_GPIO_IRQ_PRIORITY},
+    {GPIOD, {0}, "gpiod", BSP_GPIO_IRQ_PRIORITY},
+    {GPIOE, {0}, "gpioe", BSP_GPIO_IRQ_PRIORITY},
+    {GPIOF, {0}, "gpiof", BSP_GPIO_IRQ_PRIORITY},
+    {GPIOG, {0}, "gpiog", BSP_GPIO_IRQ_PRIORITY},
+    {GPIOH, {0}, "gpioh", BSP_GPIO_IRQ_PRIORITY},
+    {GPIOI, {0}, "gpioi", BSP_GPIO_IRQ_PRIORITY},
+    {GPIOJ, {0}, "gpioj", BSP_GPIO_IRQ_PRIORITY},
+};
+
+/* ===== 注册入口 ===== */
+
+void bsp_gpio_register(void)
+{
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+    __HAL_RCC_GPIOC_CLK_ENABLE();
+    __HAL_RCC_GPIOD_CLK_ENABLE();
+    __HAL_RCC_GPIOE_CLK_ENABLE();
+    __HAL_RCC_GPIOF_CLK_ENABLE();
+    __HAL_RCC_GPIOG_CLK_ENABLE();
+    __HAL_RCC_GPIOH_CLK_ENABLE();
+    __HAL_RCC_GPIOI_CLK_ENABLE();
+    __HAL_RCC_GPIOJ_CLK_ENABLE();
+
+    for (uint8_t i = 0; i < BSP_GPIO_PORT_COUNT; i++) {
+        gpio_controller_register(
+            &gBspGpio[i].parent,
+            gBspGpio[i].name,
+            BSP_GPIO_PINS_PER_PORT,
+            BSP_GPIO_IRQ_CAPS,
+            &gGpioOps,
+            &gBspGpio[i]);
+    }
+}

--- a/platform/bsp/boards/rm-a-board/source/peripherals/gpio/bsp_gpio_it.c
+++ b/platform/bsp/boards/rm-a-board/source/peripherals/gpio/bsp_gpio_it.c
@@ -1,0 +1,78 @@
+/**
+ * @file    bsp_gpio_it.c
+ * @brief   rm-a-board GPIO EXTI ISR 覆盖（override_sources）
+ */
+
+#include "bsp_gpio.h"
+
+/* ===== EXTI 端口路由（通过 SYSCFG EXTICR 确定） ===== */
+
+static int bsp_gpio_exti_port_index(uint8_t exti_line)
+{
+    volatile uint32_t *exticr = &SYSCFG->EXTICR[exti_line / 4];
+    uint32_t shift = (exti_line % 4) * 4;
+    return (int)((*exticr >> shift) & 0xF);
+}
+
+static void bsp_gpio_dispatch_exti(uint8_t pin_num)
+{
+    int port_idx = bsp_gpio_exti_port_index(pin_num);
+    if (port_idx >= 0 && port_idx < BSP_GPIO_PORT_COUNT)
+        hal_gpio_isr(&gBspGpio[port_idx].parent, pin_num);
+}
+
+/* ===== EXTI0 ~ EXTI4（单引脚 ISR） ===== */
+
+void EXTI0_IRQHandler(void)
+{
+    __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_0);
+    bsp_gpio_dispatch_exti(0);
+}
+
+void EXTI1_IRQHandler(void)
+{
+    __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_1);
+    bsp_gpio_dispatch_exti(1);
+}
+
+void EXTI2_IRQHandler(void)
+{
+    __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_2);
+    bsp_gpio_dispatch_exti(2);
+}
+
+void EXTI3_IRQHandler(void)
+{
+    __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_3);
+    bsp_gpio_dispatch_exti(3);
+}
+
+void EXTI4_IRQHandler(void)
+{
+    __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_4);
+    bsp_gpio_dispatch_exti(4);
+}
+
+/* ===== EXTI9_5 / EXTI15_10（共享 ISR） ===== */
+
+void EXTI9_5_IRQHandler(void)
+{
+    for (uint8_t pin = 5; pin <= 9; pin++) {
+        uint32_t bitmask = 1U << pin;
+        if (__HAL_GPIO_EXTI_GET_IT(bitmask)) {
+            __HAL_GPIO_EXTI_CLEAR_IT(bitmask);
+            bsp_gpio_dispatch_exti(pin);
+        }
+    }
+}
+
+void EXTI15_10_IRQHandler(void)
+{
+    for (uint8_t pin = 10; pin <= 15; pin++) {
+        uint32_t bitmask = 1U << pin;
+        if (__HAL_GPIO_EXTI_GET_IT(bitmask)) {
+            __HAL_GPIO_EXTI_CLEAR_IT(bitmask);
+            bsp_gpio_dispatch_exti(pin);
+        }
+    }
+}

--- a/platform/bsp/data/boards/rm-a-board.lua
+++ b/platform/bsp/data/boards/rm-a-board.lua
@@ -28,6 +28,7 @@ local board = {
         "boards/rm-a-board/source/core/bsp_cpu.c",
         "boards/rm-a-board/source/core/bsp_dwt.c",
         "boards/rm-a-board/source/peripherals/can/bsp_can_impl.c",
+        "boards/rm-a-board/source/peripherals/gpio/bsp_gpio_impl.c",
         "boards/rm-a-board/source/peripherals/serial/bsp_serial_impl.c",
         "boards/rm-a-board/source/peripherals/serial/bsp_serial_init.c",
         "boards/rm-a-board/source/port/om_port_hw.c",
@@ -35,6 +36,7 @@ local board = {
     override_sources = {
         -- 这些文件用于覆盖启动文件中的 weak ISR，必须直连最终 binary。
         "boards/rm-a-board/source/peripherals/can/bsp_can_it.c",
+        "boards/rm-a-board/source/peripherals/gpio/bsp_gpio_it.c",
         "boards/rm-a-board/source/peripherals/serial/serial_it.c",
     },
     osal = {


### PR DESCRIPTION
## Summary
- 框架层端口操作（write_masked/set/clear/toggle/read）统一施加 `pin_count` 掩码截断，确保越界位不会传递到 BSP
- 完善端口级 API 的 doxygen 文档：位映射约定、使用示例、STM32F4 ODR 非原子性警告
- rm-a-board（STM32F427）完整 GPIO BSP 支持：10 端口（GPIOA-J）、GpioOps 函数表、EXTI SYSCFG 动态路由

## Test plan
- [ ] rm-c-board 构建通过（xmake f --board=rm-c-board && xmake）
- [ ] rm-a-board 构建通过（xmake f --board=rm-a-board && xmake）
- [ ] xmake format --dry-run --error