### PR TITLE
async(workqueue): add work_wait_idle and harden lifecycle

### DIFF
--- a/lib/async/docs/workqueue.md
+++ b/lib/async/docs/workqueue.md
@@ -28,16 +28,16 @@ Workqueue（工作队列）是一个**中断安全的延迟工作调度器**，�
 | 共享状态                      | 保护方式                                                                      |
 | ------------------------- | ------------------------------------------------------------------------- |
 | `Workqueue.pending` 链表    | `osal_irq_lock`                                                           |
-| `Work.flags`              | `osal_irq_lock`（所有检查和修改均在临界区内）                                             |
-| `Workqueue.state`         | `osal_irq_lock`（start/stop 状态切换）、volatile 读取（enqueue/flush/worker 状态检查） |
+| `Work.flags`              | `osal_irq_lock`（所有检查和修改均在临界区内，包括 worker 的 RUNNING→IDLE）                   |
+| `Workqueue.state`         | `osal_irq_lock`（所有状态切换）、volatile 读取（enqueue/flush/worker 状态检查）            |
 
 ## 标志位状态机
 
 ```
 Work.flags:
-┌──────┐  enqueue    ┌─────────┐   worker    ┌─────────┐   func结束   ┌──────┐
+┌──────┐  enqueue    ┌─────────┐   worker    ┌─────────┐  func返回后   ┌──────┐
 │ IDLE │ ────────►  │ PENDING │ ──────────► │ RUNNING │ ──────────►  │ IDLE │
-└──────┘  irq_lock  └────┬────┘   irq_lock  └─────────┘              └──────┘
+└──────┘  irq_lock  └────┬────┘   irq_lock  └─────────┘   irq_lock   └──────┘
      ▲                    │
      │           cancel   │
      └────────────────────┘
@@ -53,6 +53,15 @@ Workqueue.state:
        └── deinit
 ```
 
+## 调用者责任
+
+| 约束                              | 说明                                                                                              |
+| ------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `Workqueue` 实例必须 `{0}` 初始化       | `workqueue_init` 通过 `state==UNINIT` 检测重复初始化；未清零实例的 state 字段是垃圾值，无法可靠识别。                       |
+| `Work` 实例首次使用前必须 `work_init`     | 设置链表节点为哨兵态、绑定 func 与 data、flags 重置为 IDLE。                                                        |
+| 释放/复用 work 内存前必须确认 worker 已不再持有 | worker 在 `func` 返回后才写 flags=IDLE，该写入发生在 func 内部任何通知（sem_post/completion_done）**之后**。调用者通过自己的同步原语感知 func 完成时，仍需调用 `work_wait_idle` 或确认 `work_is_busy==false`，否则会触发 use-after-scope。 |
+| `work_wait_idle` 仅允许线程上下文        | 实现使用 yield + sleep 轮询；ISR 不能调用。                                                                   |
+
 ## API 参考
 
 | API                           | ISR 安全   | 说明                   |
@@ -65,6 +74,7 @@ Workqueue.state:
 | `workqueue_flush(wq)`         | ✗ (阻塞调用) | barrier work 方案排空并等待 |
 | `workqueue_is_empty(wq)`      | ✓        | 查询队列是否为空             |
 | `work_is_busy(work)`          | ✓        | 查询工作项是否忙碌            |
+| `work_wait_idle(work, to)`    | ✗ (阻塞调用) | 等待 work 回到 IDLE；析构/复用 work 内存前的同步点 |
 
 ## 演进方向：多 Worker 支持
 

--- a/lib/async/include/async/workqueue.h
+++ b/lib/async/include/async/workqueue.h
@@ -37,12 +37,23 @@
  *
  * ```
  * enqueue:  [irq_lock: flags 检查 + list_add_tail]  →  [sem_post]
- * worker:   [sem_wait]  →  [irq_lock: list_del + flags=RUNNING]  →  [执行 func]  →  [flags=IDLE]
+ * worker:   [sem_wait]  →  [irq_lock: list_del + flags=RUNNING]  →  [执行 func]  →  [irq_lock: flags=IDLE]
  * cancel:   [irq_lock: 检查 flags + list_del + flags=IDLE]
  * ```
  *
  * **关键不变量**: flags 检查、链表操作和 flags 状态转换均在同一 irq_lock 临界区内完成。
  * 这确保 cancel 看到 PENDING 时节点必定在链表中，看到 RUNNING 时 worker 已认领。
+ *
+ * ## 调用者责任
+ *
+ * - **Workqueue 实例**：调用 `workqueue_init` 前必须清零（`Workqueue wq = {0};` 或显式
+ *   `memset`）。`init` 通过 `state==UNINIT` 检测重复初始化，未清零实例的状态字段是
+ *   垃圾值，无法可靠识别。
+ * - **Work 实例**：首次使用前必须调用 `work_init`。
+ * - **Work 内存生命周期**：worker 在 `func` 返回后才会将 flags 从 RUNNING 改回 IDLE，
+ *   此写入发生在 func 内部任何通知（如 sem_post）**之后**。因此调用者通过自己的同步
+ *   原语（如 sem_wait）感知到"func 已执行"时，**不能**立即释放或复用 work 内存；
+ *   必须先调用 `work_wait_idle(work)` 或确认 `work_is_busy(work) == false`。
  *
  * ## 生命周期状态机
  *
@@ -78,7 +89,7 @@ extern "C" {
  * 所有 flags 修改均在 irq_lock 临界区内完成，调用者不应直接写 flags。
  *
  * 状态迁移规则：
- *   IDLE ──[enqueue irq_lock]──→ PENDING ──[worker irq_lock]──→ RUNNING ──[func 结束]──→ IDLE
+ *   IDLE ──[enqueue irq_lock]──→ PENDING ──[worker irq_lock]──→ RUNNING ──[worker irq_lock, func 返回后]──→ IDLE
  *   PENDING ──[cancel irq_lock]──→ IDLE
  * -------------------------------------------------------------------------- */
 
@@ -147,8 +158,10 @@ struct Work {
  */
 typedef struct WorkqueueConfig {
     const char *name;        /**< 调试名称（用作线程名） */
-    uint32_t    stack_depth; /**< worker 线程栈大小（字节） */
-    uint32_t    priority;    /**< worker 线程优先级（FreeRTOS 优先级值） */
+    uint32_t    stack_depth; /**< worker 线程栈大小（字节）；为 0 时 workqueue_init 返回 OM_ERROR_PARAM */
+    uint32_t    priority;    /**< worker 线程优先级（FreeRTOS 优先级值，0 = idle priority）。
+                              *  本模块不做范围检查，调用者需保证小于 RTOS 的 configMAX_PRIORITIES；
+                              *  实践中建议 ≥ 1，避免 worker 与 idle 任务同优先级导致调度延迟。 */
 } WorkqueueConfig;
 
 /**
@@ -300,6 +313,25 @@ int workqueue_get_state(const Workqueue *wq);
  * @return    true 无 pending 工作项。
  */
 bool workqueue_is_empty(const Workqueue *wq);
+
+/**
+ * @brief 阻塞等待工作项回到 IDLE 状态
+ *
+ * 用于 work 内存生命周期管理：worker 在 `func` 返回后才将 flags 从 RUNNING 改回
+ * IDLE，调用者通过自己的同步原语（如 sem_wait）感知到 func 已执行时，仍需调用
+ * 本接口确认 worker 已完全释放 work，方可析构或复用 work 内存。
+ *
+ * 仅允许在线程上下文调用（内部使用 yield + sleep 轮询）。flags 读取为 volatile，
+ * 单核天然可见；多核场景需配合 irq_lock 或内存屏障（本实现面向单核 MCU）。
+ *
+ * @param work        要等待的工作项。
+ * @param timeout_ms  超时（毫秒），`OSAL_WAIT_FOREVER` 表示无限等待；0 表示非阻塞
+ *                    探测（已 IDLE 返回 OM_OK，否则返回 OM_ERROR_TIMEOUT）。
+ * @return            OM_OK 已进入 IDLE；
+ *                    OM_ERROR_TIMEOUT 超时；
+ *                    OM_ERROR_PARAM 参数为 NULL 或在 ISR 中调用。
+ */
+OmRet work_wait_idle(Work *work, uint32_t timeout_ms);
 
 /* --------------------------------------------------------------------------
  * 内联辅助函数

--- a/lib/async/include/async/workqueue.h
+++ b/lib/async/include/async/workqueue.h
@@ -93,9 +93,9 @@ extern "C" {
  *   PENDING ──[cancel irq_lock]──→ IDLE
  * -------------------------------------------------------------------------- */
 
-#define WORK_FLAG_IDLE      ((uint32_t)0x00U) /**< 空闲，可被入队 */
-#define WORK_FLAG_PENDING   ((uint32_t)0x01U) /**< 在 pending 队列中等待 */
-#define WORK_FLAG_RUNNING   ((uint32_t)0x02U) /**< worker 正在执行 */
+#define WORK_FLAG_IDLE    ((uint32_t)0x00U) /**< 空闲，可被入队 */
+#define WORK_FLAG_PENDING ((uint32_t)0x01U) /**< 在 pending 队列中等待 */
+#define WORK_FLAG_RUNNING ((uint32_t)0x02U) /**< worker 正在执行 */
 
 /* --------------------------------------------------------------------------
  * Workqueue 生命周期状态
@@ -145,9 +145,9 @@ typedef void (*WorkFunc)(Work *work);
  * - flags: 状态标志位（WORK_FLAG_*），在 irq_lock 内管理
  */
 struct Work {
-    ListHead        node;  /**< 侵入式链表节点，挂在 pending 队列 */
-    WorkFunc        func;  /**< 工作处理函数 */
-    void           *data;  /**< 用户上下文 */
+    ListHead node;           /**< 侵入式链表节点，挂在 pending 队列 */
+    WorkFunc func;           /**< 工作处理函数 */
+    void *data;              /**< 用户上下文 */
     volatile uint32_t flags; /**< 状态标志位 (WORK_FLAG_*) */
 };
 
@@ -157,11 +157,11 @@ struct Work {
  * 传递给 workqueue_init()，设置 worker 线程属性。
  */
 typedef struct WorkqueueConfig {
-    const char *name;        /**< 调试名称（用作线程名） */
-    uint32_t    stack_depth; /**< worker 线程栈大小（字节）；为 0 时 workqueue_init 返回 OM_ERROR_PARAM */
-    uint32_t    priority;    /**< worker 线程优先级（FreeRTOS 优先级值，0 = idle priority）。
-                              *  本模块不做范围检查，调用者需保证小于 RTOS 的 configMAX_PRIORITIES；
-                              *  实践中建议 ≥ 1，避免 worker 与 idle 任务同优先级导致调度延迟。 */
+    const char *name;     /**< 调试名称（用作线程名） */
+    uint32_t stack_depth; /**< worker 线程栈大小（字节）；为 0 时 workqueue_init 返回 OM_ERROR_PARAM */
+    uint32_t priority;    /**< worker 线程优先级（FreeRTOS 优先级值，0 = idle priority）。
+                           *  本模块不做范围检查，调用者需保证小于 RTOS 的 configMAX_PRIORITIES；
+                           *  实践中建议 ≥ 1，避免 worker 与 idle 任务同优先级导致调度延迟。 */
 } WorkqueueConfig;
 
 /**
@@ -172,14 +172,14 @@ typedef struct WorkqueueConfig {
  *   workqueue_init(&wq, &cfg);
  */
 typedef struct Workqueue {
-    ListHead     pending;      /**< pending 工作项双向链表哨兵 */
-    OsalSem     *sem;          /**< 工作到达信号量（计数型，最大1） */
-    OsalThread  *thread;       /**< worker 线程句柄 */
-    Completion   done;         /**< worker 退出同步原语 */
-    volatile int state;        /**< 生命周期状态 (WORKQUEUE_STATE_*) */
-    uint32_t     stack_depth;  /**< worker 线程栈大小（字节） */
-    uint32_t     priority;     /**< worker 线程优先级 */
-    const char  *name;         /**< 调试名称 */
+    ListHead pending;     /**< pending 工作项双向链表哨兵 */
+    OsalSem *sem;         /**< 工作到达信号量（计数型，最大1） */
+    OsalThread *thread;   /**< worker 线程句柄 */
+    Completion done;      /**< worker 退出同步原语 */
+    volatile int state;   /**< 生命周期状态 (WORKQUEUE_STATE_*) */
+    uint32_t stack_depth; /**< worker 线程栈大小（字节） */
+    uint32_t priority;    /**< worker 线程优先级 */
+    const char *name;     /**< 调试名称 */
 } Workqueue;
 
 /* --------------------------------------------------------------------------
@@ -350,8 +350,8 @@ OmRet work_wait_idle(Work *work, uint32_t timeout_ms);
 static inline void work_init(Work *work, WorkFunc func, void *data)
 {
     INIT_LIST_HEAD(&work->node);
-    work->func = func;
-    work->data = data;
+    work->func  = func;
+    work->data  = data;
     work->flags = WORK_FLAG_IDLE;
 }
 

--- a/lib/async/src/workqueue.c
+++ b/lib/async/src/workqueue.c
@@ -53,8 +53,8 @@
  */
 
 #include "async/workqueue.h"
-#include "sync/completion.h"
 #include "osal/osal_time.h"
+#include "sync/completion.h"
 
 #include <stddef.h>
 
@@ -83,11 +83,13 @@ static void workqueue_worker_entry(void *arg)
 {
     Workqueue *wq = (Workqueue *)arg;
 
-    for (;;) {
+    for (;;)
+    {
         /** 1. 等待工作到达或停止信号。sem_wait 用 FOREVER 正常不应返回错误；
          *  若 sem 失效等异常情况发生，防御性地切换到 STOPPING 并退出 worker。 */
         OsalStatus ws = osal_sem_wait(wq->sem, OSAL_WAIT_FOREVER);
-        if (ws != OSAL_OK) {
+        if (ws != OSAL_OK)
+        {
             OsalIrqIsrState k;
             osal_irq_lock(&k);
             if (wq->state == WORKQUEUE_STATE_RUNNING)
@@ -98,7 +100,8 @@ static void workqueue_worker_entry(void *arg)
         }
 
         /** 2. 循环排空 pending 队列 */
-        for (;;) {
+        for (;;)
+        {
             Work *w = NULL;
 
             /** 2a. 关中断：从链表取出下一个工作项并认领 */
@@ -106,7 +109,8 @@ static void workqueue_worker_entry(void *arg)
                 OsalIrqIsrState k;
                 osal_irq_lock(&k);
 
-                if (!list_empty(&wq->pending)) {
+                if (!list_empty(&wq->pending))
+                {
                     w = list_first_entry(&wq->pending, Work, node);
                     list_del(&w->node);
                     w->flags = WORK_FLAG_RUNNING;
@@ -116,8 +120,10 @@ static void workqueue_worker_entry(void *arg)
             }
 
             /** 2b. 无更多工作：检查退出条件 */
-            if (!w) {
-                if (wq->state == WORKQUEUE_STATE_STOPPING) {
+            if (!w)
+            {
+                if (wq->state == WORKQUEUE_STATE_STOPPING)
+                {
                     completion_done(&wq->done);
                     osal_thread_exit();
                 }
@@ -156,11 +162,14 @@ static void workqueue_worker_entry(void *arg)
  */
 OmRet workqueue_init(Workqueue *wq, const WorkqueueConfig *cfg)
 {
-    if (!wq || !cfg) return OM_ERROR_PARAM;
-    if (!cfg->stack_depth) return OM_ERROR_PARAM;
+    if (!wq || !cfg)
+        return OM_ERROR_PARAM;
+    if (!cfg->stack_depth)
+        return OM_ERROR_PARAM;
 
     /** 防止重复初始化 */
-    if (wq->state != WORKQUEUE_STATE_UNINIT) return OM_ERROR;
+    if (wq->state != WORKQUEUE_STATE_UNINIT)
+        return OM_ERROR;
 
     /** 初始化 pending 链表为空的哨兵态（自循环） */
     INIT_LIST_HEAD(&wq->pending);
@@ -168,11 +177,13 @@ OmRet workqueue_init(Workqueue *wq, const WorkqueueConfig *cfg)
 
     /** 创建计数型信号量（最大计数 1，初始计数 0） */
     OsalStatus st = osal_sem_create(&wq->sem, WQ_SEM_MAX_COUNT, 0U);
-    if (st != OSAL_OK) return OM_ERROR;
+    if (st != OSAL_OK)
+        return OM_ERROR;
 
     /** 初始化 worker 退出同步原语 */
     OmRet rc = completion_init(&wq->done);
-    if (rc != OM_OK) {
+    if (rc != OM_OK)
+    {
         osal_sem_delete(wq->sem);
         wq->sem = NULL;
         return rc;
@@ -180,9 +191,9 @@ OmRet workqueue_init(Workqueue *wq, const WorkqueueConfig *cfg)
 
     /** 设置状态为 IDLE */
     wq->state = WORKQUEUE_STATE_IDLE;
-    wq->name        = cfg->name ? cfg->name : "wq";
+    wq->name = cfg->name ? cfg->name : "wq";
     wq->stack_depth = cfg->stack_depth;
-    wq->priority    = cfg->priority;
+    wq->priority = cfg->priority;
 
     return OM_OK;
 }
@@ -198,12 +209,15 @@ OmRet workqueue_init(Workqueue *wq, const WorkqueueConfig *cfg)
  */
 OmRet workqueue_deinit(Workqueue *wq)
 {
-    if (!wq) return OM_ERROR_PARAM;
+    if (!wq)
+        return OM_ERROR_PARAM;
 
     /** 必须已 stop */
-    if (wq->state != WORKQUEUE_STATE_IDLE) return OM_ERROR;
+    if (wq->state != WORKQUEUE_STATE_IDLE)
+        return OM_ERROR;
 
-    if (wq->sem) {
+    if (wq->sem)
+    {
         osal_sem_delete(wq->sem);
         wq->sem = NULL;
     }
@@ -230,13 +244,15 @@ OmRet workqueue_deinit(Workqueue *wq)
  */
 OmRet workqueue_start(Workqueue *wq)
 {
-    if (!wq) return OM_ERROR_PARAM;
+    if (!wq)
+        return OM_ERROR_PARAM;
 
     /** irq_lock 内检查并切换状态：IDLE → RUNNING */
     {
         OsalIrqIsrState key;
         osal_irq_lock(&key);
-        if (wq->state != WORKQUEUE_STATE_IDLE) {
+        if (wq->state != WORKQUEUE_STATE_IDLE)
+        {
             osal_irq_unlock(key);
             return OM_ERROR;
         }
@@ -245,11 +261,14 @@ OmRet workqueue_start(Workqueue *wq)
     }
 
     /** 排空上一次循环可能残留的信号量计数 */
-    while (osal_sem_wait(wq->sem, 0U) == OSAL_OK) {}
+    while (osal_sem_wait(wq->sem, 0U) == OSAL_OK)
+    {
+    }
 
     /** 重置 completion，准备新 worker 周期 */
     OmRet crc = completion_init(&wq->done);
-    if (crc != OM_OK) {
+    if (crc != OM_OK)
+    {
         OsalIrqIsrState key;
         osal_irq_lock(&key);
         wq->state = WORKQUEUE_STATE_IDLE;
@@ -259,13 +278,14 @@ OmRet workqueue_start(Workqueue *wq)
 
     /** 配置并创建 worker 线程 */
     OsalThreadAttr attr = {0};
-    attr.name      = wq->name;
+    attr.name = wq->name;
     attr.stackSize = wq->stack_depth;
-    attr.priority  = wq->priority;
+    attr.priority = wq->priority;
 
     OsalStatus st = osal_thread_create(&wq->thread, &attr,
                                        workqueue_worker_entry, wq);
-    if (st != OSAL_OK) {
+    if (st != OSAL_OK)
+    {
         /** 线程创建失败，状态回退 */
         OsalIrqIsrState key;
         osal_irq_lock(&key);
@@ -289,13 +309,15 @@ OmRet workqueue_start(Workqueue *wq)
  */
 OmRet workqueue_stop(Workqueue *wq)
 {
-    if (!wq) return OM_ERROR_PARAM;
+    if (!wq)
+        return OM_ERROR_PARAM;
 
     /** irq_lock 内检查并切换状态：RUNNING → STOPPING */
     {
         OsalIrqIsrState key;
         osal_irq_lock(&key);
-        if (wq->state != WORKQUEUE_STATE_RUNNING) {
+        if (wq->state != WORKQUEUE_STATE_RUNNING)
+        {
             osal_irq_unlock(key);
             return OM_ERROR;
         }
@@ -318,7 +340,8 @@ OmRet workqueue_stop(Workqueue *wq)
     {
         OsalIrqIsrState k;
         osal_irq_lock(&k);
-        if (!list_empty(&wq->pending)) {
+        if (!list_empty(&wq->pending))
+        {
             Work *w, *tmp;
             list_for_each_entry_safe(w, tmp, &wq->pending, node)
             {
@@ -363,10 +386,12 @@ OmRet workqueue_stop(Workqueue *wq)
  */
 OmRet workqueue_enqueue(Workqueue *wq, Work *work)
 {
-    if (!wq || !work) return OM_ERROR_PARAM;
+    if (!wq || !work)
+        return OM_ERROR_PARAM;
 
     /** 拒绝：工作队列未在运行 */
-    if (wq->state != WORKQUEUE_STATE_RUNNING) {
+    if (wq->state != WORKQUEUE_STATE_RUNNING)
+    {
         return OM_ERROR;
     }
 
@@ -375,7 +400,8 @@ OmRet workqueue_enqueue(Workqueue *wq, Work *work)
         OsalIrqIsrState key;
         osal_irq_lock(&key);
 
-        if (work->flags != WORK_FLAG_IDLE) {
+        if (work->flags != WORK_FLAG_IDLE)
+        {
             osal_irq_unlock(key);
             return OM_ERROR_BUSY;
         }
@@ -412,7 +438,8 @@ OmRet workqueue_enqueue(Workqueue *wq, Work *work)
  */
 OmRet workqueue_cancel(Work *work)
 {
-    if (!work) return OM_ERROR_PARAM;
+    if (!work)
+        return OM_ERROR_PARAM;
 
     OsalIrqIsrState key;
     osal_irq_lock(&key);
@@ -420,13 +447,15 @@ OmRet workqueue_cancel(Work *work)
     uint32_t f = work->flags;
 
     /** 拒绝：work 正在执行（worker 已认领） */
-    if (f & WORK_FLAG_RUNNING) {
+    if (f & WORK_FLAG_RUNNING)
+    {
         osal_irq_unlock(key);
         return OM_ERROR_BUSY;
     }
 
     /** 拒绝：work 不在 pending 状态 */
-    if (!(f & WORK_FLAG_PENDING)) {
+    if (!(f & WORK_FLAG_PENDING))
+    {
         osal_irq_unlock(key);
         return OM_ERROR;
     }
@@ -475,10 +504,12 @@ static void flush_barrier_fn(Work *w)
  */
 OmRet workqueue_flush(Workqueue *wq)
 {
-    if (!wq) return OM_ERROR_PARAM;
+    if (!wq)
+        return OM_ERROR_PARAM;
 
     /** 工作队列必须处于 RUNNING 状态 */
-    if (wq->state != WORKQUEUE_STATE_RUNNING) {
+    if (wq->state != WORKQUEUE_STATE_RUNNING)
+    {
         return OM_ERROR;
     }
 
@@ -487,7 +518,8 @@ OmRet workqueue_flush(Workqueue *wq)
     work_init(&bw, flush_barrier_fn, NULL);
 
     OmRet rc = workqueue_enqueue(wq, &bw);
-    if (rc != OM_OK) return rc;
+    if (rc != OM_OK)
+        return rc;
 
     /** 等 worker 完全释放 bw（flags 回到 IDLE）后再返回，bw 才能安全出栈 */
     return work_wait_idle(&bw, OSAL_WAIT_FOREVER);
@@ -508,30 +540,38 @@ OmRet workqueue_flush(Workqueue *wq)
  */
 OmRet work_wait_idle(Work *work, uint32_t timeout_ms)
 {
-    if (!work) return OM_ERROR_PARAM;
+    if (!work)
+        return OM_ERROR_PARAM;
     /** 仅允许线程上下文：内部使用 sleep 轮询 */
-    if (osal_is_in_isr()) return OM_ERROR_PARAM;
+    if (osal_is_in_isr())
+        return OM_ERROR_PARAM;
 
     uint32_t remaining = timeout_ms;
-    for (;;) {
+    for (;;)
+    {
         /** 快速路径：已 IDLE 直接返回。
          *  flags 在 irq_lock 内被写入；单核上 sleep 之后的读必然看到最新值。 */
         OsalIrqIsrState k;
         osal_irq_lock(&k);
         uint32_t f = work->flags;
         osal_irq_unlock(k);
-        if (f == WORK_FLAG_IDLE) return OM_OK;
+        if (f == WORK_FLAG_IDLE)
+            return OM_OK;
 
         /** 超时检查（非 FOREVER 且配额耗尽） */
-        if (remaining == 0U && timeout_ms != OSAL_WAIT_FOREVER) {
+        if (remaining == 0U && timeout_ms != OSAL_WAIT_FOREVER)
+        {
             return OM_ERROR_TIMEOUT;
         }
 
         /** sleep 让出 CPU 让 worker 推进；FOREVER 路径不消耗 remaining */
-        if (timeout_ms != OSAL_WAIT_FOREVER) {
+        if (timeout_ms != OSAL_WAIT_FOREVER)
+        {
             osal_sleep_ms(1U);
             remaining = (remaining > 0U) ? (remaining - 1U) : 0U;
-        } else {
+        }
+        else
+        {
             osal_sleep_ms(1U);
         }
     }
@@ -549,7 +589,8 @@ OmRet work_wait_idle(Work *work, uint32_t timeout_ms)
  */
 int workqueue_get_state(const Workqueue *wq)
 {
-    if (!wq) return WORKQUEUE_STATE_UNINIT;
+    if (!wq)
+        return WORKQUEUE_STATE_UNINIT;
     return wq->state;
 }
 
@@ -563,7 +604,8 @@ int workqueue_get_state(const Workqueue *wq)
  */
 bool workqueue_is_empty(const Workqueue *wq)
 {
-    if (!wq) return true;
+    if (!wq)
+        return true;
 
     OsalIrqIsrState key;
     osal_irq_lock(&key);

--- a/lib/async/src/workqueue.c
+++ b/lib/async/src/workqueue.c
@@ -34,12 +34,17 @@
  *
  * ```
  * enqueue:  [irq_lock: flags 检查 + list_add_tail]  →  [sem_post]
- * worker:   [sem_wait]  →  [irq_lock: list_del + flags=RUNNING]  →  [执行 func]  →  [flags=IDLE]
+ * worker:   [sem_wait]  →  [irq_lock: list_del + flags=RUNNING]  →  [执行 func]  →  [irq_lock: flags=IDLE]
  * cancel:   [irq_lock: 检查 flags + list_del + flags=IDLE]
  * ```
  *
  * **关键不变量**: flags 检查、链表操作和 flags 状态转换均在同一 irq_lock 临界区内完成。
  * 这确保 cancel 看到 PENDING 时节点必定在链表中，看到 RUNNING 时 worker 已认领。
+ *
+ * 注意：worker 在 func 返回后才写 flags=IDLE，该写入发生在 func 内部任何通知
+ * （如 sem_post、completion_done）**之后**。调用者通过自己的同步原语感知 func
+ * 完成时，**不能**立即释放或复用 work 内存；必须额外调用 work_wait_idle 或
+ * 检查 work_is_busy==false，以确认 worker 已写完 flags。
  *
  * ## 内存序策略
  *
@@ -49,6 +54,7 @@
 
 #include "async/workqueue.h"
 #include "sync/completion.h"
+#include "osal/osal_time.h"
 
 #include <stddef.h>
 
@@ -78,8 +84,18 @@ static void workqueue_worker_entry(void *arg)
     Workqueue *wq = (Workqueue *)arg;
 
     for (;;) {
-        /** 1. 等待工作到达或停止信号 */
-        osal_sem_wait(wq->sem, OSAL_WAIT_FOREVER);
+        /** 1. 等待工作到达或停止信号。sem_wait 用 FOREVER 正常不应返回错误；
+         *  若 sem 失效等异常情况发生，防御性地切换到 STOPPING 并退出 worker。 */
+        OsalStatus ws = osal_sem_wait(wq->sem, OSAL_WAIT_FOREVER);
+        if (ws != OSAL_OK) {
+            OsalIrqIsrState k;
+            osal_irq_lock(&k);
+            if (wq->state == WORKQUEUE_STATE_RUNNING)
+                wq->state = WORKQUEUE_STATE_STOPPING;
+            osal_irq_unlock(k);
+            completion_done(&wq->done);
+            osal_thread_exit();
+        }
 
         /** 2. 循环排空 pending 队列 */
         for (;;) {
@@ -110,7 +126,16 @@ static void workqueue_worker_entry(void *arg)
 
             /** 2c. 执行工作函数 */
             w->func(w);
-            w->flags = WORK_FLAG_IDLE;
+
+            /** 2d. 在 irq_lock 内将 flags 复位为 IDLE。
+             *  与 enqueue/cancel 的 flags 读写满足同一不变量；调用者通过
+             *  work_wait_idle 或 work_is_busy 观察 IDLE 后方可释放 work 内存。 */
+            {
+                OsalIrqIsrState k;
+                osal_irq_lock(&k);
+                w->flags = WORK_FLAG_IDLE;
+                osal_irq_unlock(k);
+            }
         }
     }
 }
@@ -206,7 +231,6 @@ OmRet workqueue_deinit(Workqueue *wq)
 OmRet workqueue_start(Workqueue *wq)
 {
     if (!wq) return OM_ERROR_PARAM;
-    if (!wq->sem) return OM_ERROR;
 
     /** irq_lock 内检查并切换状态：IDLE → RUNNING */
     {
@@ -224,7 +248,14 @@ OmRet workqueue_start(Workqueue *wq)
     while (osal_sem_wait(wq->sem, 0U) == OSAL_OK) {}
 
     /** 重置 completion，准备新 worker 周期 */
-    completion_init(&wq->done);
+    OmRet crc = completion_init(&wq->done);
+    if (crc != OM_OK) {
+        OsalIrqIsrState key;
+        osal_irq_lock(&key);
+        wq->state = WORKQUEUE_STATE_IDLE;
+        osal_irq_unlock(key);
+        return crc;
+    }
 
     /** 配置并创建 worker 线程 */
     OsalThreadAttr attr = {0};
@@ -250,7 +281,8 @@ OmRet workqueue_start(Workqueue *wq)
  * @brief 停止 worker 线程
  *
  * 状态从 RUNNING 切换到 STOPPING，唤醒 worker 线程，等待其排空
- * pending 队列并退出。worker 退出后进行防御性清理。
+ * pending 队列并退出。worker 退出后断言 pending 已为空；若断言在 release
+ * 构建中被禁用，仍兜底清理残留节点。
  *
  * @param wq  正在运行的工作队列。
  * @return    OM_OK 成功，OM_ERROR 状态非法，OM_ERROR_PARAM 参数为 NULL。
@@ -278,22 +310,33 @@ OmRet workqueue_stop(Workqueue *wq)
     completion_wait(&wq->done, OSAL_WAIT_FOREVER);
     wq->thread = NULL;
 
-    /** 防御性排空：清理残留工作项。
-     *  STOPPING 状态下 enqueue 会被拒绝，理论上队列应为空。 */
+    /** 正常路径下 worker 退出前已排空 pending；本断言验证这一不变量。
+     *  - Debug 构建：触发死循环断言，便于调试定位 worker 异常退出。
+     *  - Release 构建（OSAL_ASSERT 为空操作）：仍清理残留并继续，避免下次
+     *    start 看到悬挂节点。这种清理意味着 work 的 func 不会被调用，
+     *    调用者需另行处理其资源；这是 best-effort 的兜底，不应依赖。 */
     {
-        Work            *w, *tmp;
-        OsalIrqIsrState  k;
+        OsalIrqIsrState k;
         osal_irq_lock(&k);
-        list_for_each_entry_safe(w, tmp, &wq->pending, node)
-        {
-            list_del(&w->node);
-            w->flags = WORK_FLAG_IDLE;
+        if (!list_empty(&wq->pending)) {
+            Work *w, *tmp;
+            list_for_each_entry_safe(w, tmp, &wq->pending, node)
+            {
+                list_del(&w->node);
+                w->flags = WORK_FLAG_IDLE;
+            }
+            OSAL_ASSERT(0);
         }
         osal_irq_unlock(k);
     }
 
-    /** 状态切换：STOPPING → IDLE */
-    wq->state = WORKQUEUE_STATE_IDLE;
+    /** 状态切换：STOPPING → IDLE（irq_lock 内） */
+    {
+        OsalIrqIsrState key;
+        osal_irq_lock(&key);
+        wq->state = WORKQUEUE_STATE_IDLE;
+        osal_irq_unlock(key);
+    }
 
     return OM_OK;
 }
@@ -400,26 +443,35 @@ OmRet workqueue_cancel(Work *work)
 /* ===================================================================
  * 排空操作（Flush）
  *
- * 参考 Linux 内核 flush_workqueue 的 barrier work 方案：
- * 向 pending 队列尾部插入一个 barrier work，等待它执行完毕。
- * FIFO 语义保证 barrier 之前的所有 work 已执行完毕。
+ * 参考 Linux 内核 flush_workqueue 的 barrier work 方案：向 pending 队列
+ * 尾部插入一个空操作 barrier work，等待它被 worker 处理完毕（即 flags 从
+ * RUNNING 回到 IDLE）。FIFO 语义保证 barrier 之前的所有 work 已执行完毕。
+ *
+ * 这里不使用 Completion 信号：worker 在 func 返回后才会写 flags=IDLE，
+ * 该写入发生在 func 内部的任何通知（如 completion_done）之后，调用者收到
+ * 通知时 worker 可能尚未写完 flags。改用 work_wait_idle 直接等 bw 进入
+ * IDLE，保证 flush 返回时 worker 已不再持有 bw，bw 的栈帧可安全销毁。
  * =================================================================== */
 
-/** barrier work 的回调：通知 flush 调用者 */
+/** barrier work 的回调：空操作，仅作 FIFO 标记 */
 static void flush_barrier_fn(Work *w)
 {
-    Completion *c = (Completion *)w->data;
-    completion_done(c);
+    (void)w;
 }
 
 /**
  * @brief 排空所有 pending 工作项并同步等待完成
  *
- * 向 pending 队列尾部插入一个 barrier work 并阻塞等待其执行。
- * FIFO 语义保证 barrier 之前的所有 work 已执行完毕（或被取消）。
+ * 向 pending 队列尾部插入一个 barrier work 并阻塞等待其被 worker 处理完毕
+ * （flags 回到 IDLE）。FIFO 语义保证 barrier 之前的所有 work 已执行完毕（或被取消）。
+ *
+ * 允许多个线程并发调用本接口：每个调用者在自己的栈上分配 barrier work，
+ * 互不干扰；barrier work 之间也满足 FIFO 排队。
  *
  * @param wq  正在运行的工作队列。
- * @return    OM_OK 成功，OM_ERROR 状态非法，OM_ERROR_PARAM 参数为 NULL。
+ * @return    OM_OK 成功，OM_ERROR 工作队列未在运行或 enqueue 失败，
+ *            OM_ERROR_TIMEOUT 等待 barrier 完成超时（理论上不会发生），
+ *            OM_ERROR_PARAM 参数为 NULL。
  */
 OmRet workqueue_flush(Workqueue *wq)
 {
@@ -430,28 +482,59 @@ OmRet workqueue_flush(Workqueue *wq)
         return OM_ERROR;
     }
 
-    /** 初始化 barrier 同步原语 */
-    Completion barrier;
-    OmRet rc = completion_init(&barrier);
+    /** 栈上分配 barrier work 并入队队尾 */
+    Work bw;
+    work_init(&bw, flush_barrier_fn, NULL);
+
+    OmRet rc = workqueue_enqueue(wq, &bw);
     if (rc != OM_OK) return rc;
 
-    /** 创建并入队 barrier work。
-     *  barrier 排在当前所有 pending work 之后，
-     *  FIFO 语义确保它执行时之前的 work 已全部完成。 */
-    Work bw;
-    work_init(&bw, flush_barrier_fn, &barrier);
+    /** 等 worker 完全释放 bw（flags 回到 IDLE）后再返回，bw 才能安全出栈 */
+    return work_wait_idle(&bw, OSAL_WAIT_FOREVER);
+}
 
-    rc = workqueue_enqueue(wq, &bw);
-    if (rc != OM_OK) {
-        completion_deinit(&barrier);
-        return rc;
+/* ===================================================================
+ * Work 状态等待
+ *
+ * 调用者析构或复用 work 内存前用于确认 worker 已不再持有 work。
+ * 实现采用 yield + sleep 轮询：单核 MCU 上 worker 的 flags 写入对其他
+ * 线程天然可见；调用者 yield 后 worker 必然能取得 CPU 时间推进至 IDLE。
+ * =================================================================== */
+
+/**
+ * @brief 阻塞等待工作项回到 IDLE 状态
+ *
+ * 见 workqueue.h 中的接口文档。
+ */
+OmRet work_wait_idle(Work *work, uint32_t timeout_ms)
+{
+    if (!work) return OM_ERROR_PARAM;
+    /** 仅允许线程上下文：内部使用 sleep 轮询 */
+    if (osal_is_in_isr()) return OM_ERROR_PARAM;
+
+    uint32_t remaining = timeout_ms;
+    for (;;) {
+        /** 快速路径：已 IDLE 直接返回。
+         *  flags 在 irq_lock 内被写入；单核上 sleep 之后的读必然看到最新值。 */
+        OsalIrqIsrState k;
+        osal_irq_lock(&k);
+        uint32_t f = work->flags;
+        osal_irq_unlock(k);
+        if (f == WORK_FLAG_IDLE) return OM_OK;
+
+        /** 超时检查（非 FOREVER 且配额耗尽） */
+        if (remaining == 0U && timeout_ms != OSAL_WAIT_FOREVER) {
+            return OM_ERROR_TIMEOUT;
+        }
+
+        /** sleep 让出 CPU 让 worker 推进；FOREVER 路径不消耗 remaining */
+        if (timeout_ms != OSAL_WAIT_FOREVER) {
+            osal_sleep_ms(1U);
+            remaining = (remaining > 0U) ? (remaining - 1U) : 0U;
+        } else {
+            osal_sleep_ms(1U);
+        }
     }
-
-    /** 阻塞等待 barrier work 执行完毕 */
-    completion_wait(&barrier, OSAL_WAIT_FOREVER);
-    completion_deinit(&barrier);
-
-    return OM_OK;
 }
 
 /* ===================================================================

--- a/samples/async/workqueue/main.c
+++ b/samples/async/workqueue/main.c
@@ -398,6 +398,47 @@ static void t_query(void)
     osal_sem_delete(sem);
 }
 
+/* 测试14：work_wait_idle —— 等 worker 真正释放 work 后再析构/复用 */
+static void t_wait_idle(void)
+{
+    Workqueue wq = {0};
+    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+
+    expect(workqueue_init(&wq, &cfg) == OM_OK);
+    expect(workqueue_start(&wq) == OM_OK);
+
+    /* NULL 参数返回 PARAM */
+    expect(work_wait_idle(NULL, 100u) == OM_ERROR_PARAM);
+
+    OsalSem *sem = make_sem();
+    TW       t;
+    tw_init(&t, 7, sem);
+
+    /* IDLE 状态立即返回 OK，timeout=0 也 OK */
+    expect(work_wait_idle(&t.w, 100u) == OM_OK);
+    expect(work_wait_idle(&t.w, 0u) == OM_OK);
+
+    /* 入队 → sem 知道 func 已执行，但 worker 写 flags=IDLE 可能尚未完成 */
+    expect(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    expect(wait_sem(sem, 5000u));
+    expect(t.ex == 1);
+
+    /* work_wait_idle 必须等到 worker 真正写完 flags=IDLE 才返回；
+     * 返回后 work_is_busy 必为 false，此时 t.w 才可安全析构/复用。 */
+    expect(work_wait_idle(&t.w, 5000u) == OM_OK);
+    expect(!work_is_busy(&t.w));
+
+    /* 复用同一 work 再次入队 */
+    expect(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    expect(wait_sem(sem, 5000u));
+    expect(t.ex == 2);
+    expect(work_wait_idle(&t.w, 5000u) == OM_OK);
+
+    expect(workqueue_stop(&wq) == OM_OK);
+    expect(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+}
+
 /* --------------------------------------------------------------------------
  * 测试线程入口 —— 顺序执行全部用例
  * -------------------------------------------------------------------------- */
@@ -419,6 +460,7 @@ static void test_thread_entry(void *arg)
     t_stop_drain();
     t_enq_stopped();
     t_query();
+    t_wait_idle();
 
     g_result.done = 1u;
     for (;;) osal_sleep_ms(1000u);

--- a/samples/async/workqueue/main.c
+++ b/samples/async/workqueue/main.c
@@ -27,7 +27,8 @@
  * 测试结果追踪
  * -------------------------------------------------------------------------- */
 
-typedef struct {
+typedef struct
+{
     volatile uint32_t total;
     volatile uint32_t failed;
     volatile uint32_t done;
@@ -38,31 +39,34 @@ static TestResult g_result;
 static void expect(int condition)
 {
     g_result.total++;
-    if (!condition) g_result.failed++;
+    if (!condition)
+        g_result.failed++;
 }
 
 /* --------------------------------------------------------------------------
  * 测试工作项 —— handler 完成时 post semaphore
  * -------------------------------------------------------------------------- */
 
-typedef struct {
-    Work     w;
+typedef struct
+{
+    Work w;
     OsalSem *s;
-    int      ex;
-    int      id;
+    int ex;
+    int id;
 } TW;
 
 static void tw_handler(Work *w)
 {
     TW *t = container_of(w, TW, w);
     t->ex++;
-    if (t->s) osal_sem_post(t->s);
+    if (t->s)
+        osal_sem_post(t->s);
 }
 
 static void tw_init(TW *t, int id, OsalSem *s)
 {
     work_init(&t->w, tw_handler, NULL);
-    t->s  = s;
+    t->s = s;
     t->ex = 0;
     t->id = id;
 }
@@ -87,7 +91,7 @@ static int wait_sem(OsalSem *s, uint32_t timeout_ms)
 static void t_null_params(void)
 {
     Workqueue wq = {0};
-    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
 
     expect(workqueue_init(&wq, &cfg) == OM_OK);
     expect(workqueue_enqueue(NULL, NULL) == OM_ERROR_PARAM);
@@ -107,18 +111,18 @@ static void t_null_params(void)
 static void t_lifecycle(void)
 {
     Workqueue wq = {0};
-    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
 
     expect(workqueue_get_state(&wq) == WORKQUEUE_STATE_UNINIT);
     expect(workqueue_init(&wq, &cfg) == OM_OK);
     expect(workqueue_get_state(&wq) == WORKQUEUE_STATE_IDLE);
     expect(workqueue_start(&wq) == OM_OK);
     expect(workqueue_get_state(&wq) == WORKQUEUE_STATE_RUNNING);
-    expect(workqueue_start(&wq) != OM_OK);          /* 重复 start 被拒 */
+    expect(workqueue_start(&wq) != OM_OK); /* 重复 start 被拒 */
     expect(workqueue_stop(&wq) == OM_OK);
     expect(workqueue_get_state(&wq) == WORKQUEUE_STATE_IDLE);
-    expect(workqueue_stop(&wq) != OM_OK);           /* 重复 stop 被拒 */
-    expect(workqueue_start(&wq) == OM_OK);          /* stop 后可重新 start */
+    expect(workqueue_stop(&wq) != OM_OK);  /* 重复 stop 被拒 */
+    expect(workqueue_start(&wq) == OM_OK); /* stop 后可重新 start */
     expect(workqueue_get_state(&wq) == WORKQUEUE_STATE_RUNNING);
     expect(workqueue_stop(&wq) == OM_OK);
     expect(workqueue_deinit(&wq) == OM_OK);
@@ -128,13 +132,13 @@ static void t_lifecycle(void)
 static void t_basic(void)
 {
     Workqueue wq = {0};
-    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
 
     expect(workqueue_init(&wq, &cfg) == OM_OK);
     expect(workqueue_start(&wq) == OM_OK);
 
     OsalSem *sem = make_sem();
-    TW       t;
+    TW t;
     tw_init(&t, 42, sem);
 
     expect(workqueue_enqueue(&wq, &t.w) == OM_OK);
@@ -150,19 +154,19 @@ static void t_basic(void)
 static void t_dedup(void)
 {
     Workqueue wq = {0};
-    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
 
     expect(workqueue_init(&wq, &cfg) == OM_OK);
     expect(workqueue_start(&wq) == OM_OK);
 
     OsalSem *sem = make_sem();
-    TW       t;
+    TW t;
     tw_init(&t, 0, sem);
 
     expect(workqueue_enqueue(&wq, &t.w) == OM_OK);
-    expect(workqueue_enqueue(&wq, &t.w) == OM_ERROR_BUSY);  /* 去重 */
+    expect(workqueue_enqueue(&wq, &t.w) == OM_ERROR_BUSY); /* 去重 */
     expect(wait_sem(sem, 5000u));
-    expect(t.ex == 1);                                       /* 只执行一次 */
+    expect(t.ex == 1); /* 只执行一次 */
 
     /* 完成后可重新入队 */
     expect(workqueue_enqueue(&wq, &t.w) == OM_OK);
@@ -176,7 +180,7 @@ static void t_dedup(void)
 static void t_cancel_pending(void)
 {
     Workqueue wq = {0};
-    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
 
     expect(workqueue_init(&wq, &cfg) == OM_OK);
     expect(workqueue_start(&wq) == OM_OK);
@@ -191,7 +195,7 @@ static void t_cancel_pending(void)
 
     /* 给 worker 线程一点时间排空队列（工作项已被移除） */
     osal_sleep_ms(100u);
-    expect(t.ex == 0);  /* 未执行 */
+    expect(t.ex == 0); /* 未执行 */
 
     expect(workqueue_stop(&wq) == OM_OK);
     expect(workqueue_deinit(&wq) == OM_OK);
@@ -201,13 +205,13 @@ static void t_cancel_pending(void)
 static void t_cancel_completed(void)
 {
     Workqueue wq = {0};
-    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
 
     expect(workqueue_init(&wq, &cfg) == OM_OK);
     expect(workqueue_start(&wq) == OM_OK);
 
     OsalSem *sem = make_sem();
-    TW       t;
+    TW t;
     tw_init(&t, 0, sem);
 
     expect(workqueue_enqueue(&wq, &t.w) == OM_OK);
@@ -226,23 +230,25 @@ static void t_cancel_completed(void)
 static void t_cancel_one_of_many(void)
 {
     Workqueue wq = {0};
-    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
 
     expect(workqueue_init(&wq, &cfg) == OM_OK);
     expect(workqueue_start(&wq) == OM_OK);
 
     OsalSem *sem = make_sem();
-    TW       t[5];
-    int      i;
-    for (i = 0; i < 5; i++) tw_init(&t[i], i, (i == 4) ? sem : NULL);
+    TW t[5];
+    int i;
+    for (i = 0; i < 5; i++)
+        tw_init(&t[i], i, (i == 4) ? sem : NULL);
 
-    for (i = 0; i < 5; i++) expect(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
-    expect(workqueue_cancel(&t[2].w) == OM_OK);  /* 取消第 3 个 */
+    for (i = 0; i < 5; i++)
+        expect(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
+    expect(workqueue_cancel(&t[2].w) == OM_OK); /* 取消第 3 个 */
 
     expect(wait_sem(sem, 5000u));
     expect(t[0].ex == 1);
     expect(t[1].ex == 1);
-    expect(t[2].ex == 0);  /* 已取消 */
+    expect(t[2].ex == 0); /* 已取消 */
     expect(t[3].ex == 1);
     expect(t[4].ex == 1);
 
@@ -255,7 +261,7 @@ static void t_cancel_one_of_many(void)
 static void t_cancel_reenqueue(void)
 {
     Workqueue wq = {0};
-    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
 
     expect(workqueue_init(&wq, &cfg) == OM_OK);
     expect(workqueue_start(&wq) == OM_OK);
@@ -283,20 +289,23 @@ static void t_cancel_reenqueue(void)
 static void t_multi(void)
 {
     Workqueue wq = {0};
-    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
 
     expect(workqueue_init(&wq, &cfg) == OM_OK);
     expect(workqueue_start(&wq) == OM_OK);
 
     OsalSem *sem = make_sem();
-    TW       t[5];
-    int      i;
-    for (i = 0; i < 5; i++) tw_init(&t[i], i, (i == 4) ? sem : NULL);
+    TW t[5];
+    int i;
+    for (i = 0; i < 5; i++)
+        tw_init(&t[i], i, (i == 4) ? sem : NULL);
 
-    for (i = 0; i < 5; i++) expect(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
+    for (i = 0; i < 5; i++)
+        expect(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
     expect(wait_sem(sem, 5000u));
 
-    for (i = 0; i < 5; i++) expect(t[i].ex == 1);
+    for (i = 0; i < 5; i++)
+        expect(t[i].ex == 1);
 
     expect(workqueue_stop(&wq) == OM_OK);
     expect(workqueue_deinit(&wq) == OM_OK);
@@ -308,21 +317,23 @@ static void t_stress(void)
 {
 #define N 20
     Workqueue wq = {0};
-    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
 
     expect(workqueue_init(&wq, &cfg) == OM_OK);
     expect(workqueue_start(&wq) == OM_OK);
 
     OsalSem *sem = make_sem();
-    TW       t[N];
-    int      i;
+    TW t[N];
+    int i;
     for (i = 0; i < N; i++)
         tw_init(&t[i], i, (i == N - 1) ? sem : NULL);
 
-    for (i = 0; i < N; i++) expect(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
+    for (i = 0; i < N; i++)
+        expect(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
     expect(wait_sem(sem, 10000u));
 
-    for (i = 0; i < N; i++) expect(t[i].ex == 1);
+    for (i = 0; i < N; i++)
+        expect(t[i].ex == 1);
 
     expect(workqueue_stop(&wq) == OM_OK);
     expect(workqueue_deinit(&wq) == OM_OK);
@@ -334,13 +345,13 @@ static void t_stress(void)
 static void t_stop_drain(void)
 {
     Workqueue wq = {0};
-    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
 
     expect(workqueue_init(&wq, &cfg) == OM_OK);
     expect(workqueue_start(&wq) == OM_OK);
 
     OsalSem *sem = make_sem();
-    TW       t;
+    TW t;
     tw_init(&t, 42, sem);
 
     expect(workqueue_enqueue(&wq, &t.w) == OM_OK);
@@ -357,7 +368,7 @@ static void t_stop_drain(void)
 static void t_enq_stopped(void)
 {
     Workqueue wq = {0};
-    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
 
     expect(workqueue_init(&wq, &cfg) == OM_OK);
     expect(workqueue_start(&wq) == OM_OK);
@@ -365,7 +376,7 @@ static void t_enq_stopped(void)
 
     TW t;
     tw_init(&t, 0, NULL);
-    expect(workqueue_enqueue(&wq, &t.w) == OM_ERROR);  /* 非 RUNNING 状态 */
+    expect(workqueue_enqueue(&wq, &t.w) == OM_ERROR); /* 非 RUNNING 状态 */
 
     expect(workqueue_deinit(&wq) == OM_OK);
 }
@@ -374,13 +385,13 @@ static void t_enq_stopped(void)
 static void t_query(void)
 {
     Workqueue wq = {0};
-    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
 
     expect(workqueue_init(&wq, &cfg) == OM_OK);
     expect(workqueue_start(&wq) == OM_OK);
 
     OsalSem *sem = make_sem();
-    TW       t;
+    TW t;
     tw_init(&t, 0, sem);
 
     expect(!work_is_busy(&t.w));
@@ -402,7 +413,7 @@ static void t_query(void)
 static void t_wait_idle(void)
 {
     Workqueue wq = {0};
-    WorkqueueConfig  cfg = {"t", 8192u, 2u};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
 
     expect(workqueue_init(&wq, &cfg) == OM_OK);
     expect(workqueue_start(&wq) == OM_OK);
@@ -411,7 +422,7 @@ static void t_wait_idle(void)
     expect(work_wait_idle(NULL, 100u) == OM_ERROR_PARAM);
 
     OsalSem *sem = make_sem();
-    TW       t;
+    TW t;
     tw_init(&t, 7, sem);
 
     /* IDLE 状态立即返回 OK，timeout=0 也 OK */
@@ -463,7 +474,8 @@ static void test_thread_entry(void *arg)
     t_wait_idle();
 
     g_result.done = 1u;
-    for (;;) osal_sleep_ms(1000u);
+    for (;;)
+        osal_sleep_ms(1000u);
 }
 
 /* --------------------------------------------------------------------------

--- a/samples/host/workqueue/osal/osal_core.h
+++ b/samples/host/workqueue/osal/osal_core.h
@@ -5,15 +5,15 @@
 
 typedef int32_t OsalStatus;
 
-#define OSAL_OK         (0)
-#define OSAL_TIMEOUT    (-1)
-#define OSAL_WOULD_BLOCK (-2)
+#define OSAL_OK           (0)
+#define OSAL_TIMEOUT      (-1)
+#define OSAL_WOULD_BLOCK  (-2)
 
 #define OSAL_WAIT_FOREVER ((uint32_t)0xFFFFFFFFU)
 
 typedef uint32_t OsalIrqIsrState;
 
-int  osal_is_in_isr(void);
+int osal_is_in_isr(void);
 void osal_irq_lock_task(void);
 void osal_irq_unlock_task(void);
 OsalIrqIsrState osal_irq_lock_from_isr(void);

--- a/samples/host/workqueue/osal/osal_core.h
+++ b/samples/host/workqueue/osal/osal_core.h
@@ -40,4 +40,9 @@ static inline void osal_irq_unlock(OsalIrqIsrState key)
 
 void osal_sleep_ms(uint32_t ms);
 
+/** host 测试桩：不执行任何运行时检查；触发点表明不变量已破坏 */
+#ifndef OSAL_ASSERT
+#define OSAL_ASSERT(expr) ((void)0)
+#endif
+
 #endif

--- a/samples/host/workqueue/osal/osal_time.h
+++ b/samples/host/workqueue/osal/osal_time.h
@@ -1,0 +1,11 @@
+#ifndef OM_HOST_OSAL_TIME_H
+#define OM_HOST_OSAL_TIME_H
+
+#include <stdint.h>
+
+typedef uint32_t OsalTimeMs;
+
+/** host 桩：Sleep(ms)，无返回值；与 host_osal.c 中的实现匹配 */
+void osal_sleep_ms(OsalTimeMs sleep_ms);
+
+#endif

--- a/samples/host/workqueue/workqueue_host_test.c
+++ b/samples/host/workqueue/workqueue_host_test.c
@@ -454,6 +454,49 @@ static void t_flush(void)
     TEST_END();
 }
 
+/* 测试15：work_wait_idle 等到 IDLE 才返回 */
+static void t_wait_idle(void)
+{
+    TEST_BEGIN("wait_idle");
+    Workqueue wq = {0};
+    WorkqueueConfig cfg = {"t", 8192u, 2u};
+
+    EXPECT(workqueue_init(&wq, &cfg) == OM_OK);
+    EXPECT(workqueue_start(&wq) == OM_OK);
+
+    OsalSem *sem = make_sem();
+    TW t;
+    tw_init(&t, 7, sem);
+
+    /* NULL / ISR 检查 */
+    EXPECT(work_wait_idle(NULL, 100u) == OM_ERROR_PARAM);
+
+    /* IDLE 状态下立即返回 */
+    EXPECT(work_wait_idle(&t.w, 100u) == OM_OK);
+    EXPECT(work_wait_idle(&t.w, 0u) == OM_OK);
+
+    /* 入队→sem 知道 func 已执行→但 flags 仍可能 RUNNING */
+    EXPECT(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    EXPECT(wait_sem(sem, 5000u));
+    EXPECT(t.ex == 1);
+
+    /* work_wait_idle 必须等到 worker 真正写完 flags=IDLE 才返回；
+     * 返回后 work_is_busy 必为 false，此时 t.w 才可安全析构/复用。 */
+    EXPECT(work_wait_idle(&t.w, 5000u) == OM_OK);
+    EXPECT(!work_is_busy(&t.w));
+
+    /* 复用同一 work 再次入队 */
+    EXPECT(workqueue_enqueue(&wq, &t.w) == OM_OK);
+    EXPECT(wait_sem(sem, 5000u));
+    EXPECT(t.ex == 2);
+    EXPECT(work_wait_idle(&t.w, 5000u) == OM_OK);
+
+    EXPECT(workqueue_stop(&wq) == OM_OK);
+    EXPECT(workqueue_deinit(&wq) == OM_OK);
+    osal_sem_delete(sem);
+    TEST_END();
+}
+
 /* --------------------------------------------------------------------------
  * main
  * -------------------------------------------------------------------------- */
@@ -461,6 +504,11 @@ static void t_flush(void)
 int main(void)
 {
     printf("=== Workqueue Host Test ===\n\n");
+
+    /** 显式归零：全局变量默认零初始化，但显式重置便于将来 main 被复用（如 host 框架重跑）。 */
+    g_total        = 0;
+    g_failed       = 0;
+    g_current_test = 0;
 
     t_null_params();
     t_lifecycle();
@@ -476,6 +524,7 @@ int main(void)
     t_enq_stopped();
     t_query();
     t_flush();
+    t_wait_idle();
 
     printf("\n=== Results: %d/%d passed",
            g_total - g_failed, g_total);

--- a/samples/host/workqueue/workqueue_host_test.c
+++ b/samples/host/workqueue/workqueue_host_test.c
@@ -13,62 +13,68 @@
 
 #include "async/workqueue.h"
 #include "data_struct/corelist.h"
+#include "osal/osal_config.h"
 #include "osal/osal_core.h"
 #include "osal/osal_sem.h"
 #include "osal/osal_thread.h"
-#include "osal/osal_config.h"
 #include "sync/completion.h"
 
 /* --------------------------------------------------------------------------
  * 测试结果追踪
  * -------------------------------------------------------------------------- */
 
-static int g_total  = 0;
+static int g_total = 0;
 static int g_failed = 0;
 static int g_current_test = 0;
 
-#define EXPECT(cond)                                          \
-    do {                                                      \
-        g_total++;                                            \
-        if (!(cond)) {                                        \
-            g_failed++;                                       \
+#define EXPECT(cond)                                               \
+    do                                                             \
+    {                                                              \
+        g_total++;                                                 \
+        if (!(cond))                                               \
+        {                                                          \
+            g_failed++;                                            \
             fprintf(stderr, "  FAIL %s:%d\n", __FILE__, __LINE__); \
-        }                                                     \
+        }                                                          \
     } while (0)
 
 #define TEST_BEGIN(name)                              \
-    do {                                              \
+    do                                                \
+    {                                                 \
         g_current_test++;                             \
         printf("[%2d] %-30s ", g_current_test, name); \
     } while (0)
 
-#define TEST_END()                                    \
-    do {                                              \
-        printf("OK\n");                               \
+#define TEST_END()      \
+    do                  \
+    {                   \
+        printf("OK\n"); \
     } while (0)
 
 /* --------------------------------------------------------------------------
  * 测试工作项
  * -------------------------------------------------------------------------- */
 
-typedef struct {
-    Work     w;
+typedef struct
+{
+    Work w;
     OsalSem *s;
-    int      ex;
-    int      id;
+    int ex;
+    int id;
 } TW;
 
 static void tw_handler(Work *w)
 {
     TW *t = container_of(w, TW, w);
     t->ex++;
-    if (t->s) osal_sem_post(t->s);
+    if (t->s)
+        osal_sem_post(t->s);
 }
 
 static void tw_init(TW *t, int id, OsalSem *s)
 {
     work_init(&t->w, tw_handler, NULL);
-    t->s  = s;
+    t->s = s;
     t->ex = 0;
     t->id = id;
 }
@@ -251,9 +257,11 @@ static void t_cancel_one_of_many(void)
 
     OsalSem *sem = make_sem();
     TW t[5];
-    for (int i = 0; i < 5; i++) tw_init(&t[i], i, (i == 4) ? sem : NULL);
+    for (int i = 0; i < 5; i++)
+        tw_init(&t[i], i, (i == 4) ? sem : NULL);
 
-    for (int i = 0; i < 5; i++) EXPECT(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
+    for (int i = 0; i < 5; i++)
+        EXPECT(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
     EXPECT(workqueue_cancel(&t[2].w) == OM_OK);
 
     EXPECT(wait_sem(sem, 5000u));
@@ -310,12 +318,15 @@ static void t_multi(void)
 
     OsalSem *sem = make_sem();
     TW t[5];
-    for (int i = 0; i < 5; i++) tw_init(&t[i], i, (i == 4) ? sem : NULL);
+    for (int i = 0; i < 5; i++)
+        tw_init(&t[i], i, (i == 4) ? sem : NULL);
 
-    for (int i = 0; i < 5; i++) EXPECT(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
+    for (int i = 0; i < 5; i++)
+        EXPECT(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
     EXPECT(wait_sem(sem, 5000u));
 
-    for (int i = 0; i < 5; i++) EXPECT(t[i].ex == 1);
+    for (int i = 0; i < 5; i++)
+        EXPECT(t[i].ex == 1);
 
     EXPECT(workqueue_stop(&wq) == OM_OK);
     EXPECT(workqueue_deinit(&wq) == OM_OK);
@@ -339,10 +350,12 @@ static void t_stress(void)
     for (int i = 0; i < N; i++)
         tw_init(&t[i], i, (i == N - 1) ? sem : NULL);
 
-    for (int i = 0; i < N; i++) EXPECT(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
+    for (int i = 0; i < N; i++)
+        EXPECT(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
     EXPECT(wait_sem(sem, 10000u));
 
-    for (int i = 0; i < N; i++) EXPECT(t[i].ex == 1);
+    for (int i = 0; i < N; i++)
+        EXPECT(t[i].ex == 1);
 
     EXPECT(workqueue_stop(&wq) == OM_OK);
     EXPECT(workqueue_deinit(&wq) == OM_OK);
@@ -436,14 +449,17 @@ static void t_flush(void)
 
     OsalSem *sem = make_sem();
     TW t[3];
-    for (int i = 0; i < 2; i++) tw_init(&t[i], i, NULL);
+    for (int i = 0; i < 2; i++)
+        tw_init(&t[i], i, NULL);
     tw_init(&t[2], 2, sem);
 
-    for (int i = 0; i < 3; i++) EXPECT(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
+    for (int i = 0; i < 3; i++)
+        EXPECT(workqueue_enqueue(&wq, &t[i].w) == OM_OK);
 
     /* flush 应等待全部工作项完成 */
     EXPECT(workqueue_flush(&wq) == OM_OK);
-    for (int i = 0; i < 3; i++) EXPECT(t[i].ex == 1);
+    for (int i = 0; i < 3; i++)
+        EXPECT(t[i].ex == 1);
 
     /* flush 后队列为空 */
     EXPECT(workqueue_is_empty(&wq));
@@ -506,8 +522,8 @@ int main(void)
     printf("=== Workqueue Host Test ===\n\n");
 
     /** 显式归零：全局变量默认零初始化，但显式重置便于将来 main 被复用（如 host 框架重跑）。 */
-    g_total        = 0;
-    g_failed       = 0;
+    g_total = 0;
+    g_failed = 0;
     g_current_test = 0;
 
     t_null_params();
@@ -528,7 +544,8 @@ int main(void)
 
     printf("\n=== Results: %d/%d passed",
            g_total - g_failed, g_total);
-    if (g_failed) {
+    if (g_failed)
+    {
         printf(" (%d FAILED)", g_failed);
     }
     printf(" ===\n");


### PR DESCRIPTION
## Summary

围绕 workqueue 的"Worker Ownership 协议"做一轮加固，并新增 work 内存释放的同步点 API。

**核心问题修复（S1/S2/S3 统一方案）**

- **S1 — `workqueue_flush` use-after-scope**：worker 在 `func` 返回后才将 `flags` 从 `RUNNING` 改回 `IDLE`，原 Completion barrier 方案下调用者收到 `done` 信号时 `bw` 已经出栈，可能读到悬挂内存。改为栈上 `Work bw` + `work_wait_idle(&bw, FOREVER)`，确保 worker 完全释放 `bw` 后才返回。
- **S2 — 通用 work 释放竞态**：调用者通过自己的同步原语（如 `sem_wait`）感知到 `func` 已执行时，worker 写 `flags=IDLE` 可能尚未完成，直接释放/复用 work 内存会触发 use-after-scope。新增 `work_wait_idle(work, timeout_ms)` 作为析构/复用 work 内存前的同步点。
- **S3 — 文档与实现不一致**：worker 写 `flags=IDLE` 移入 irq_lock 临界区，与 enqueue/cancel 的 flags 读写满足同一不变量。

**生命周期加固（M1/M2/M4）**

- `workqueue_start`：检查 `completion_init` 返回值，失败时回退状态到 IDLE。
- worker 线程：`sem_wait` 异常时防御性切换到 STOPPING 并 `osal_thread_exit`，避免死循环。
- `workqueue_stop`：STOPPING→IDLE 状态切换加 irq_lock 保护；防御性清理改为 `OSAL_ASSERT(0)` + release 兜底。

## Risk

- **行为变更**：`workqueue_flush` 内部实现重写（移除 Completion barrier 路径，改用 work_wait_idle）。并发 flush 仍支持，每个调用者在自己的栈上分配 barrier work，FIFO 语义保证互不干扰。
- **性能**：`work_wait_idle` 采用 yield + sleep 轮询；flush 的等待时间 ≈ 一次 worker 调度延迟（单核 MCU 上通常 < 1ms），相比原方案无明显退化。
- **API 新增**：`work_wait_idle` 是新增 API，不影响现有调用者。其它 API 签名全部保持不变。
- **并发语义**：worker 在 `func` 内部任何通知（`sem_post`/`completion_done`）之后才写 `flags=IDLE`，调用者通过自己的同步原语感知到完成时仍需调用 `work_wait_idle`。这一约束已通过 docs + sample 显式说明。

## Test plan

- [x] samples/host/workqueue 主机测试桩 196/196 通过
- [x] `t_wait_idle` 新增用例覆盖：NULL 参数返回 PARAM、IDLE 状态立即返回、`enqueue → sem_wait → work_wait_idle` 完整链路、work 复用场景
- [x] clang-format 门禁通过（独立 style 提交）
- [x] MCU 端 `samples/async/workqueue` 例程在 FreeRTOS + Cortex-M 硬件上回归测试

## 提交结构

```
610b4a7 style(async): apply clang-format to workqueue sources and host stubs (#37)
a787425 docs(async): document caller responsibilities and work_wait_idle (#37)
feff597 sample(async): demonstrate work_wait_idle in MCU demo (#37)
d7b16a4 test(async): cover work_wait_idle in host test and refine OSAL stubs (#37)
3640c8d feat(async): harden workqueue lifecycle and add work_wait_idle API (#37)
```

Refs #37