### PR TITLE
refactor(spi): remove DoubleBuf, adopt zero-copy path; add 16-bit DMA support

### DIFF
--- a/lib/drivers/docs/spi_design.md
+++ b/lib/drivers/docs/spi_design.md
@@ -3,7 +3,7 @@
 > 版本：v4.0
 > 日期：2026-06-26
 > 基于：Linux kernel spi_summary / Zephyr spi.h / ESP-IDF spi_master.h
-> 项目约束：Device 模型、DoubleBuf/Completion/OsalMutex/Workqueue 基础设施
+> 项目约束：Device 模型、Completion/OsalMutex/Workqueue 基础设施
 
 ---
 
@@ -37,11 +37,10 @@
 +====================================================================+
 |  SpiBus (Bus Controller — NOT registered as Device)                |
 |  - hwPrivate / ops / lock / lastCfgDev / actualHz                  |
-|  - txDbuf / transferDone / busy / asyncWq (framework-builtin wq)  |
-|  - prefillMsg / prefillEpoch (peek prefill tracking)                |
+|  - transferDone / busy / asyncWq (framework-builtin wq)             |
 |  - suspendedCount / deviceCount (suspend ref-counting)              |
 |  - deviceList / busNode (linked list membership)                    |
-|  Responsibilities: Mutex, reconfig cache, DoubleBuf, Completion    |
+|  Responsibilities: Mutex, reconfig cache, Completion, workqueue     |
 |                    workqueue serialization, suspend gate             |
 +====================================================================+
            |
@@ -112,10 +111,6 @@
             │  │  lastCfgDev        (config cache, ptr)   │ │
             │  │  actualHz           (feedback from BSP)   │ │
             │  ├─────────────────────────────────────────┤ │
-            │  │  txDbuf: DoubleBuf  (TX ping-pong buffer) │ │
-            │  │  prefillMsg         (peek prefill target) │ │
-            │  │  prefillEpoch       (anti-dangle epoch)   │ │
-            │  ├─────────────────────────────────────────┤ │
             │  │  transferDone: Completion (ISR→thread)    │ │
             │  │  lastStatus / lastTransferred             │ │
             │  │  busy: volatile     (ISR gate)            │ │
@@ -138,7 +133,7 @@
 
 **关键关系**：
 - HalSpiDevice **引用** SpiBus（多对一），不拥有
-- SpiBus **拥有** OsalMutex、Completion、DoubleBuf、Workqueue
+- SpiBus **拥有** OsalMutex、Completion、Workqueue
 - SpiBus 通过 `ops` 函数表 **委托** BSP 执行硬件操作
 - SpiBus 通过 `hwPrivate` 不透明指针持有 BSP 私有数据
 - Device 父类通过全局链表 `parent.list` 注册到设备表
@@ -229,9 +224,6 @@ typedef struct SpiBus {
     HalSpiDevice      *lastCfgDev;    /* 当前已配置的设备指针 */
     uint32_t           actualHz;      /* 当前 SCLK 实际频率（分频后真实值，由 configure 填充） */
 
-    /* ---- 双缓冲（TX-only，dbuf_page_size > 0 时启用） ---- */
-    DoubleBuf          txDbuf;
-
     /* ---- 同步传输完成信号 ---- */
     Completion         transferDone;
     size_t             lastTransferred;  /* ISR 写入，同步路径读取 */
@@ -239,10 +231,6 @@ typedef struct SpiBus {
 
     /* ---- 硬件传输状态 ---- */
     volatile uint8_t   busy;             /* 硬件传输进行中（ISR 门控） */
-
-    /* ---- Peek 预填充追踪 ---- */
-    SpiMessage        *prefillMsg;       /* 预填充目标 message（NULL=无预填） */
-    uint32_t           prefillEpoch;     /* 预填充时的请求 epoch（防悬垂复用） */
 
     /* ---- 异步调度（框架自建 per-bus workqueue） ---- */
     Workqueue          asyncWq;
@@ -314,9 +302,8 @@ typedef struct HalSpiDevice {
 
 ```c
 OmRet   spi_bus_register(SpiBus *bus, void *hw_private,
-                        SpiControllerOps *ops, size_t dbuf_page_size);
-/* dbuf_page_size > 0: 分配 2×dbuf_page_size 并初始化 txDbuf，启用 CPU/DMA 并行
- * dbuf_page_size == 0: 跳过 DoubleBuf，transfer_async 仍可用 */
+                        SpiControllerOps *ops);
+/* 分配 lock + completion + workqueue，将 bus 注册到全局总线链表 */
 
 void    spi_bus_unregister(SpiBus *bus);
 /* 从全局总线表摘除，不释放内部资源（反操作 register），可 re-register */
@@ -401,15 +388,14 @@ void hal_spi_isr(SpiBus *bus, OmRet status, size_t transferred);
 | 2 | **CS 管理** | 双路径：GPIO（框架直控 gpio_pin_write）+ 硬件 CS（setCs 回调降级） | Linux gpiod / Zephyr gpio_dt_spec | GPIO 子系统复用，ACTIVE_LOW 自动反转；硬件 CS 走 controller==NULL 路径 |
 | 3 | **异步调度** | Per-bus 单 worker workqueue + per-device async slot | Linux per-controller kthread | ISR 极薄（写 lastStatus/lastTransferred + completion_done）；框架内部化，调用者无感知 |
 | 4 | **异步 slot** | HalSpiDevice 内嵌 async Work/SpiMessage*/callback，irq_lock 保护 asyncBusy | — | 消除 SpiAsyncRequest 动态分配，零 malloc；同一设备仅 1 个在途请求 |
-| 5 | **双缓冲** | 框架内部 TX DoubleBuf，dbuf_page_size 控制启停 | Linux/ESP-IDF | dbuf_page_size>0 启用 Peek 预填充并行优化（CPU 预填下一段数据与 DMA 并行） |
-| 6 | **DMA 集成** | BSP Private 完全透明 | ESP-IDF/NuttX | DMA 通道/IRQ/句柄全在 BSP；框架只通过 transferOne 契约间接驱动 |
-| 7 | **错误模型** | SPI 别名 → OM 通用码（OM_ERR_TIMEOUT/IO/INVALID_ARG/BUSY/NOT_SUPPORTED） | OM OmRet 体系 | 无模块专属错误枚举，统一命名空间，通用语义优先 |
-| 8 | **配置缓存** | lastCfgDev 指针比较 | RT-Thread | 单指令，无哈希，IMU 1kHz 无效重配全部消除 |
-| 9 | **actualHz 反馈** | configure 回写 bus->actualHz，超时公式用实际频率 | Linux spi_controller.min_speed_hz | 分频器离散量化可能导致实际频率偏离 maxHz，超时必须基于真实值 |
-| 10 | **总线发现** | spi_bus_get(idx) — 纯逻辑序号，全局链表 + irq_lock 保护 | Linux spi_bus_num | 上层零 BSP 依赖；无硬编码容量上限；链表操作微秒级 |
-| 11 | **生命周期** | register / unregister / deinit 三态分离 | — | unregister 可逆（摘表不销毁），deinit 不可逆（前提 deviceCount==0，持锁销毁） |
-| 12 | **SpiBus 不可见** | 不注册为 Device | Linux/ESP-IDF | 用户永远操作从设备，总线是内部基础设施 |
-| 13 | **超时** | 动态计算 = (len × 8 × 1000 / actualHz) + transferOverheadMs | Linux/ESP-IDF | 每次传输根据实际长度和 actualHz 计算，短传输短超时 |
+| 5 | **DMA 集成** | BSP Private 完全透明 | ESP-IDF/NuttX | DMA 通道/IRQ/句柄全在 BSP；框架只通过 transferOne 契约间接驱动 |
+| 6 | **错误模型** | SPI 别名 → OM 通用码（OM_ERR_TIMEOUT/IO/INVALID_ARG/BUSY/NOT_SUPPORTED） | OM OmRet 体系 | 无模块专属错误枚举，统一命名空间，通用语义优先 |
+| 7 | **配置缓存** | lastCfgDev 指针比较 | RT-Thread | 单指令，无哈希，IMU 1kHz 无效重配全部消除 |
+| 8 | **actualHz 反馈** | configure 回写 bus->actualHz，超时公式用实际频率 | Linux spi_controller.min_speed_hz | 分频器离散量化可能导致实际频率偏离 maxHz，超时必须基于真实值 |
+| 9 | **总线发现** | spi_bus_get(idx) — 纯逻辑序号，全局链表 + irq_lock 保护 | Linux spi_bus_num | 上层零 BSP 依赖；无硬编码容量上限；链表操作微秒级 |
+| 10 | **生命周期** | register / unregister / deinit 三态分离 | — | unregister 可逆（摘表不销毁），deinit 不可逆（前提 deviceCount==0，持锁销毁） |
+| 11 | **SpiBus 不可见** | 不注册为 Device | Linux/ESP-IDF | 用户永远操作从设备，总线是内部基础设施 |
+| 12 | **超时** | 动态计算 = (len × 8 × 1000 / actualHz) + transferOverheadMs | Linux/ESP-IDF | 每次传输根据实际长度和 actualHz 计算，短传输短超时 |
 
 ---
 
@@ -489,21 +475,14 @@ spi_transfer_async(dev, msg, callback, param)
   ├─ spi_ensure_configured(bus, dev)
   │
   ├─ for each SpiTransfer in msg:
-  │    ├─ DoubleBuf 数据就位:
-  │    │    ├─ [预填命中] msg==prefillMsg && epoch==prefillEpoch → dbuf_swap (零拷贝)
-  │    │    └─ [未命中] dbuf_flush 丢弃失效预填 → memcpy + commit → 更新写指针
+  │    ├─ tx_src = xfer->txBuf（零拷贝，DMA 直接从 caller buffer 读取）
   │    ├─ busy=1 → ops->transferOne() → [失败] busy=0, goto cleanup
   │    ├─ unlock → completion_wait(timeout)
-  │    │    ├─ Peek 预填充 (DoubleBuf 启用时):
-  │    │    │    irq_lock → 查看下一段 transfer
-  │    │    │    memcpy(write_page, next->txBuf, next->len)
-  │    │    │    dbuf_mark_written → prefillMsg=msg, prefillEpoch=asyncEpoch
-  │    │    └─ irq_unlock
   │    ├─ [超时] irq_lock→busy=0, drain completion, lock, msg->status=TIMEOUT, goto cleanup
   │    ├─ msg->transferred += bus->lastTransferred
   │    ├─ [硬件错误] bus->lastStatus != OK → goto cleanup
   │    ├─ CS_HOLD? asyncCsHeld=true : deassert, asyncCsHeld=false
-  │    └─ 最后一段? busy=0 + dbuf_consume : lock 重检 suspend/detach
+  │    └─ lock 重检 suspend/detach
   │
   ├─ msg->status = OM_OK
   │

--- a/lib/drivers/include/drivers/peripheral/spi/pal_spi_dev.h
+++ b/lib/drivers/include/drivers/peripheral/spi/pal_spi_dev.h
@@ -14,7 +14,6 @@
 
 #include "async/workqueue.h"
 #include "core/om_def.h"
-#include "data_struct/double_buf.h"
 #include "drivers/model/device.h"
 #include "drivers/peripheral/gpio/pal_gpio_dev.h"
 #include "osal/osal_mutex.h"
@@ -175,9 +174,6 @@ typedef struct SpiBus {
     HalSpiDevice      *lastCfgDev;    /* 当前已配置的设备指针 */
     uint32_t           actualHz;      /* 当前 SCLK 实际频率（分频后的真实值，由 configure 填充） */
 
-    /* ---- 双缓冲（TX-only，dbuf_page_size > 0 时启用） ---- */
-    DoubleBuf          txDbuf;
-
     /* ---- 同步传输完成信号 ---- */
     Completion         transferDone;
     size_t             lastTransferred;  /* ISR 写入，同步路径读取 */
@@ -185,10 +181,6 @@ typedef struct SpiBus {
 
     /* ---- 硬件传输状态 ---- */
     volatile uint8_t   busy;             /* 硬件传输进行中（ISR 门控，需 volatile） */
-
-    /* ---- Peek 预填充追踪 ---- */
-    SpiMessage        *prefillMsg;       /* 预填充目标消息（NULL=无预填） */
-    uint32_t           prefillEpoch;     /* 预填充时的请求 epoch（防悬垂复用） */
 
     /* ---- 异步调度（框架自建 per-bus workqueue） ---- */
     Workqueue          asyncWq;
@@ -254,7 +246,7 @@ void spi_cs_deassert(HalSpiDevice *dev);
  *===========================================================================*/
 
 OmRet  spi_bus_register(SpiBus *bus, void *hw_private,
-                        SpiControllerOps *ops, size_t dbuf_page_size);
+                        SpiControllerOps *ops);
 
 /** @brief 从全局总线表中摘除（反操作：register），不释放内部资源 */
 void   spi_bus_unregister(SpiBus *bus);

--- a/lib/drivers/src/peripheral/spi/hal_spi.c
+++ b/lib/drivers/src/peripheral/spi/hal_spi.c
@@ -112,15 +112,6 @@ static uint32_t spi_calc_timeout_ms(size_t len, uint32_t actual_hz, uint32_t ove
 }
 
 /*===========================================================================
- * 内部辅助 — DoubleBuf 开关
- *===========================================================================*/
-
-static inline bool spi_dbuf_enabled(SpiBus *bus)
-{
-    return dbuf_capacity(&bus->txDbuf) > 0U;
-}
-
-/*===========================================================================
  * 内部辅助 — 单段硬件传输
  *
  * busy=1 必须在 transferOne 之前设置：DMA 可能在 transferOne 内部同步完成，
@@ -168,7 +159,7 @@ static void spi_async_worker_func(Work *work);
  *===========================================================================*/
 
 OmRet spi_bus_register(SpiBus *bus, void *hw_private,
-                        SpiControllerOps *ops, size_t dbuf_page_size)
+                        SpiControllerOps *ops)
 {
     if (!bus || !ops)
         return OM_ERR_NULL;
@@ -192,15 +183,6 @@ OmRet spi_bus_register(SpiBus *bus, void *hw_private,
         return ret;
     }
 
-    if (dbuf_page_size > 0U) {
-        if (!dbuf_alloc(&bus->txDbuf, dbuf_page_size, NULL)) {
-            completion_deinit(&bus->transferDone);
-            osal_mutex_delete(bus->lock);
-            bus->lock = NULL;
-            return OM_ERR_NO_MEM;
-        }
-    }
-
     WorkqueueConfig wq_cfg = {
         .name        = "spi_async",
         .stack_depth = SPI_ASYNC_WQ_STACK_DEPTH,
@@ -208,7 +190,6 @@ OmRet spi_bus_register(SpiBus *bus, void *hw_private,
     };
     ret = workqueue_init(&bus->asyncWq, &wq_cfg);
     if (ret != OM_OK) {
-        dbuf_free(&bus->txDbuf, NULL);
         completion_deinit(&bus->transferDone);
         osal_mutex_delete(bus->lock);
         bus->lock = NULL;
@@ -217,7 +198,6 @@ OmRet spi_bus_register(SpiBus *bus, void *hw_private,
     ret = workqueue_start(&bus->asyncWq);
     if (ret != OM_OK) {
         workqueue_deinit(&bus->asyncWq);
-        dbuf_free(&bus->txDbuf, NULL);
         completion_deinit(&bus->transferDone);
         osal_mutex_delete(bus->lock);
         bus->lock = NULL;
@@ -255,7 +235,6 @@ void spi_bus_deinit(SpiBus *bus)
 
     workqueue_stop(&bus->asyncWq);
     workqueue_deinit(&bus->asyncWq);
-    dbuf_free(&bus->txDbuf, NULL);
     completion_deinit(&bus->transferDone);
 
     /* 先取走 mutex 指针再置 NULL，防止 unlock→delete 间隙被其他线程抢锁 */
@@ -762,20 +741,6 @@ static void spi_async_worker_func(Work *work)
         }
 
         const uint8_t *tx_src = xfer->txBuf;
-        if (spi_dbuf_enabled(bus) && xfer->txBuf) {
-            if (dbuf_is_pending(&bus->txDbuf) && msg == bus->prefillMsg
-                && dev->asyncEpoch == bus->prefillEpoch) {
-                dbuf_swap(&bus->txDbuf);
-                bus->prefillMsg = NULL;
-            } else {
-                if (dbuf_is_pending(&bus->txDbuf))
-                    dbuf_flush(&bus->txDbuf);
-                bus->prefillMsg = NULL;
-                memcpy(dbuf_get_write_ptr(&bus->txDbuf), xfer->txBuf, xfer->len);
-                dbuf_commit(&bus->txDbuf, xfer->len);
-            }
-            tx_src = dbuf_get_read_ptr(&bus->txDbuf, NULL);
-        }
 
         uint32_t timeout = spi_calc_timeout_ms(xfer->len, bus->actualHz,
                                                 dev->cfg.transferOverheadMs);
@@ -790,21 +755,6 @@ static void spi_async_worker_func(Work *work)
 
         spi_bus_unlock(bus);
         locked = false;
-
-        if (spi_dbuf_enabled(bus)) {
-            OsalIrqIsrState k;
-            osal_irq_lock(&k);
-            if (i + 1U < msg->count) {
-                SpiTransfer *next = &msg->transfers[i + 1U];
-                if (next->txBuf) {
-                    memcpy(dbuf_get_write_ptr(&bus->txDbuf), next->txBuf, next->len);
-                    dbuf_mark_written(&bus->txDbuf, next->len);
-                    bus->prefillMsg   = msg;
-                    bus->prefillEpoch = dev->asyncEpoch;
-                }
-            }
-            osal_irq_unlock(k);
-        }
 
         ret = completion_wait(&bus->transferDone, timeout);
         if (ret == OM_ERR_TIMEOUT) {
@@ -855,8 +805,6 @@ static void spi_async_worker_func(Work *work)
         } else {
             spi_bus_lock(bus);
             bus->busy = 0;
-            if (spi_dbuf_enabled(bus))
-                dbuf_consume(&bus->txDbuf);
             spi_bus_unlock(bus);
         }
     }

--- a/platform/bsp/boards/rm-a-board/include/bsp_spi.h
+++ b/platform/bsp/boards/rm-a-board/include/bsp_spi.h
@@ -100,10 +100,10 @@ typedef struct BspSpi
     SpiBus             parent;       /* 第 1 字段：框架 SpiBus */
     SPI_HandleTypeDef  handle;       /* 第 2 字段：HAL 句柄（含 hdmatx/hdmarx 链接） */
 
-    /* DMA dummy 单字节缓冲：tx/rx==NULL 时 DMA 源/目标。
-     * 配合运行时切 DMA_SxCR.MINC（MINC=0 循环读单字节），支持任意 len。 */
-    uint8_t            dummyTx;      /* tx==NULL 时 DMA 源，固定 0xFF */
-    uint8_t            dummyRx;      /* rx==NULL 时 DMA 目标，丢弃 */
+    /* DMA dummy 缓冲：tx/rx==NULL 时 DMA 源/目标。uint16_t 兼容 8/16-bit
+     * 两种数据宽度（16-bit 模式下 DMA HALFWORD 访问需 2 字节对齐）。 */
+    uint16_t           dummyTx;      /* tx==NULL 时 DMA 源，固定 0xFFFF */
+    uint16_t           dummyRx;      /* rx==NULL 时 DMA 目标，丢弃 */
     size_t             pendingLen;   /* 当前传输总长，abort 反算用 */
 } BspSpi_s;
 
@@ -116,8 +116,8 @@ typedef struct BspSpi
 
 /**
  * @brief 静态初始化宏（用于全局 gBspSpi[] 数组）
- * @note  dummyTx = 0xFF（SPI 约定 dummy 字节），dummyRx = 0（丢弃）。
- *        dummy 单字节配合 transferOne 内 MINC=0 循环读，len 无上限。
+ * @note  dummyTx = 0xFFFF（SPI 约定 dummy），dummyRx = 0（丢弃）。
+ *        uint16_t 兼容 8/16-bit DMA 宽度，MINC=0 循环读，len 无上限。
  *        固定 Init 字段（Mode/Direction/NSS/TIMode/CRCCalculation/CRCPolynomial）
  *        在此静态赋初值，configure 中不再重复设置：
  *        - Mode           = MASTER
@@ -139,8 +139,8 @@ typedef struct BspSpi
             .CRCCalculation = SPI_CRCCALCULATION_DISABLE,          \
             .CRCPolynomial  = 7U,                                  \
         },                                                         \
-        .dummyTx         = 0xFFU,                                  \
-        .dummyRx         = 0x00U,                                  \
+        .dummyTx         = 0xFFFFU,                                \
+        .dummyRx         = 0x0000U,                                \
         .pendingLen      = 0U,                                     \
     }
 

--- a/platform/bsp/boards/rm-a-board/source/peripherals/spi/bsp_spi_impl.c
+++ b/platform/bsp/boards/rm-a-board/source/peripherals/spi/bsp_spi_impl.c
@@ -144,62 +144,84 @@ static OmRet bsp_spi_configure(SpiBus *bus, const SpiDeviceCfg *cfg)
 
 /**
  * @brief 启动全双工 DMA 传输（异步）
- * @note  tx==NULL → DMA 源指向 &bsp_spi->dummyTx（单字节 0xFF），DMA MINC=0 循环读
- *        rx==NULL → DMA 目标指向 &bsp_spi->dummyRx（单字节），DMA MINC=0 循环写
+ * @note  tx==NULL → DMA 源指向 &bsp_spi->dummyTx（MINC=0 循环读）
+ *        rx==NULL → DMA 目标指向 &bsp_spi->dummyRx（MINC=0 循环写）
+ *        DMA MSIZE/PSIZE 在 8/16-bit 模式间动态切换，NDTR 同步调整。
  *        返回 OM_OK 表示 DMA 已启动，真正的完成信号由 DMA RX IRQ 触发。
  *
  *        HAL_SPI_TransmitReceive_DMA 内部会配置两个 DMA stream 的方向/
  *        对齐/长度并启动，最终 RX stream TC 触发 HAL_SPI_TxRxCpltCallback。
  *
- *        DMA_SxCR.MINC 切换契约（RM0090 §9.5.5）：
- *          - MINC 位写入要求 EN=0
+ *        DMA_SxCR.MINC/MSIZE/PSIZE 切换契约（RM0090 §9.5.5）：
+ *          - CR 配置位写入要求 EN=0
  *          - Normal 模式下，前次传输 NDTR=0 时硬件自动清 EN
- *          - HAL_DMA_Start_IT / DMA_SetConfig 全程不写 CR.MINC
- *          - 故 transferOne 入口时 EN=0 恒成立，可自由切 MINC，len 无上限
+ *          - HAL_DMA_Start_IT / DMA_SetConfig 全程不写 CR.MINC/MSIZE/PSIZE
+ *          - 故 transferOne 入口时 EN=0 恒成立，可自由切 MINC/MSIZE/PSIZE，len 无上限
  */
 static OmRet bsp_spi_transfer_one(SpiBus *bus, const uint8_t *tx, uint8_t *rx, size_t len)
 {
     if (!bus)
         return OM_ERR_INVALID_ARG;
 
-    BspSpi_t bsp_spi = (BspSpi_t)bus->hwPrivate;
+    BspSpi_t          bsp_spi = (BspSpi_t)bus->hwPrivate;
+    SPI_HandleTypeDef *hspi   = &bsp_spi->handle;
+    bool              is16bit = (hspi->Init.DataSize == SPI_DATASIZE_16BIT);
 
-    /* 记录 pendingLen 供 abort 反算与 ISR 上报 */
+    /* 记录 pendingLen（字节数）供 abort 反算与 ISR 上报 */
     bsp_spi->pendingLen = len;
 
+    /* DMA 数据宽度：8-bit 模式用 BYTE，16-bit 模式用 HALFWORD。
+     * NDTR 在 16-bit 时为 len/2（半字数），8-bit 时为 len（字节数）。
+     * MSIZE/PSIZE 切换要求 EN=0，Normal 模式前次传输完成后硬件已自动清 EN。 */
+    uint32_t dma_width_mask = DMA_SxCR_MSIZE | DMA_SxCR_PSIZE;
+    uint32_t dma_width_val;
+    uint16_t dma_size;
+
+    DMA_Stream_TypeDef *stream_tx = hspi->hdmatx->Instance;
+    DMA_Stream_TypeDef *stream_rx = hspi->hdmarx->Instance;
+
+    if (is16bit) {
+        dma_width_val = DMA_SxCR_MSIZE_0 | DMA_SxCR_PSIZE_0; /* HALFWORD */
+        dma_size      = (uint16_t)(len / 2U);
+    } else {
+        dma_width_val = 0U; /* BYTE */
+        dma_size      = (uint16_t)len;
+    }
+
+    MODIFY_REG(stream_tx->CR, dma_width_mask, dma_width_val);
+    MODIFY_REG(stream_rx->CR, dma_width_mask, dma_width_val);
+
     /* tx/rx NULL 处理：DMA_SxCR.MINC 按 NULL 切换。
-     * 非 NULL → MINC=1（连续 buffer），NULL → MINC=0（单字节循环）。 */
+     * 非 NULL → MINC=1（连续 buffer），NULL → MINC=0（单元素循环）。 */
     const uint8_t *tx_src;
-    DMA_Stream_TypeDef *stream_tx = bsp_spi->handle.hdmatx->Instance;
     if (tx) {
         SET_BIT(stream_tx->CR, DMA_SxCR_MINC);
         tx_src = tx;
     } else {
         CLEAR_BIT(stream_tx->CR, DMA_SxCR_MINC);
-        tx_src = &bsp_spi->dummyTx;
+        tx_src = (const uint8_t *)&bsp_spi->dummyTx;
     }
 
-    uint8_t        *rx_dst;
-    DMA_Stream_TypeDef *stream_rx = bsp_spi->handle.hdmarx->Instance;
+    uint8_t *rx_dst;
     if (rx) {
         SET_BIT(stream_rx->CR, DMA_SxCR_MINC);
         rx_dst = rx;
     } else {
         CLEAR_BIT(stream_rx->CR, DMA_SxCR_MINC);
-        rx_dst = &bsp_spi->dummyRx;
+        rx_dst = (uint8_t *)&bsp_spi->dummyRx;
     }
 
     /* SPE=1 后 SPI 可能产生幽灵 RXNE（第二个或更多），出现在 configure 的
      * flush 之后、HAL_SPI_TransmitReceive_DMA 开 RXDMAEN 之前。不在此处清掉，
      * RXDMAEN 一开 DMA 就会预读旧 DR，rxb 收到错误数据。
      * 必须在调用 HAL 前紧邻刷新（bsp_spi_configure 里已做过第一次）。 */
-    if (__HAL_SPI_GET_FLAG(&bsp_spi->handle, SPI_FLAG_RXNE))
-        (void)READ_REG(bsp_spi->handle.Instance->DR);
+    if (__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_RXNE))
+        (void)READ_REG(hspi->Instance->DR);
 
     /* 启动全双工 DMA。HAL_StatusTypeDef != HAL_OK 时返回错误码，
      * 此时**不得**调 hal_spi_isr（bsp_implementer_checklist.md §3.2）。 */
     HAL_StatusTypeDef hal_ret =
-        HAL_SPI_TransmitReceive_DMA(&bsp_spi->handle, (uint8_t *)tx_src, rx_dst, (uint16_t)len);
+        HAL_SPI_TransmitReceive_DMA(hspi, (uint8_t *)tx_src, rx_dst, dma_size);
 
     if (hal_ret != HAL_OK)
         return OM_ERR_IO;
@@ -232,11 +254,14 @@ static OmRet bsp_spi_control(SpiBus *bus, uint32_t cmd, void *arg)
             HAL_DMA_Abort(hspi->hdmarx);
         /* 2. 关 SPI */
         __HAL_SPI_DISABLE(hspi);
-        /* 3. 反算已传输字节数：pendingLen - RX DMA 剩余计数 */
+        /* 3. 反算已传输字节数：pendingLen - RX DMA 剩余计数。
+         *    16-bit 模式下 NDTR 是半字数，需 ×2 转为字节数。 */
         size_t transferred = 0U;
         if (hspi->hdmarx)
         {
             size_t remain = __HAL_DMA_GET_COUNTER(hspi->hdmarx);
+            if (hspi->Init.DataSize == SPI_DATASIZE_16BIT)
+                remain *= 2U;
             transferred = (bsp_spi->pendingLen >= remain)
                               ? (bsp_spi->pendingLen - remain)
                               : 0U;
@@ -302,11 +327,10 @@ void bsp_spi_register(void)
          *    因为 spi_bus_register 不做任何硬件工作，只分配 lock/completion） */
         bsp_spi_pre_init(&gBspSpi[i]);
 
-        /* 2. 注册 SpiBus 到框架（dbuf_page_size=0：不开启 DoubleBuf） */
+        /* 2. 注册 SpiBus 到框架 */
         OmRet ret = spi_bus_register(&gBspSpi[i].parent,
                                          &gBspSpi[i],
-                                         &gSpiOps,
-                                         0U);
+                                         &gSpiOps);
         (void)ret; /* TODO: 失败处理策略待框架层统一 */
     }
 }


### PR DESCRIPTION
## Summary

- Remove DoubleBuf integration from SPI framework — adopt Linux zero-copy model where DMA reads directly from caller buffer
- Simplify spi_bus_register signature by dropping dbuf_page_size parameter
- Update spi_design.md to reflect zero-copy architecture
- BSP: upgrade dummyTx/dummyRx to uint16_t for 8/16-bit DMA width compatibility
- BSP: add DMA MSIZE/PSIZE dynamic switching in transferOne and ABORT byte-count fix for 16-bit mode

## Changes

| File | Description |
|---|---|
| pal_spi_dev.h | Drop DoubleBuf txDbuf, prefillMsg, prefillEpoch fields; remove dbuf_page_size param |
| hal_spi.c | Remove all dbuf branches from async worker, register, deinit |
| spi_design.md | Purge dbuf/DoubleBuf/prefill; reflow async worker diagram |
| bsp_spi.h |  dummyTx/dummyRx to uint16_t; 0xFFFF/0x0000 default |
| bsp_spi_impl.c |  DMA width switching; 16-bit NDTR fix in ABORT; adapt register call |

## Impact

- SRAM: saves 2 x page_size bytes per bus
- Flash: about 4KB reduction (dbuf logic + Tier 10 tests removed)
- Per-transfer: saves one memcpy (zero-copy path)
- DoubleBuf data structure preserved as general-purpose library (lib/data_struct/)

## Test Plan

- [x] All 23 hw tests pass (Tier 1-9, loopback on rm-a-board)
- [x] ICM42688 IMU sample works correctly
- [x] 16-bit DMA transfer verified via logic analyzer
